### PR TITLE
TS typing of crossfilter

### DIFF
--- a/client/__tests__/util/typedCrossfilter/sort.test.ts
+++ b/client/__tests__/util/typedCrossfilter/sort.test.ts
@@ -183,7 +183,7 @@ describe("sortIndex", () => {
 
 describe("lowerBound", () => {
   test("non-float path", () => {
-    expect(lowerBound([], 0, 0, 0)).toEqual(0);
+    expect(lowerBound(<number[]>[], 0, 0, 0)).toEqual(0);
 
     expect(lowerBound([0, 1, 2, 3], -1, 0, 4)).toEqual(0);
     expect(lowerBound([0, 1, 2, 3], 0, 0, 4)).toEqual(0);

--- a/client/__tests__/util/typedCrossfilter/util.test.ts
+++ b/client/__tests__/util/typedCrossfilter/util.test.ts
@@ -1,7 +1,4 @@
-import {
-  sliceByIndex,
-  makeSortIndex,
-} from "../../../src/util/typedCrossfilter/util";
+import { makeSortIndex } from "../../../src/util/typedCrossfilter/util";
 import { rangeFill as fillRange } from "../../../src/util/range";
 
 describe("fillRange", () => {
@@ -19,59 +16,6 @@ describe("fillRange", () => {
       new Uint32Array([1, 2, 3, 4])
     );
     expect(fillRange([])).toMatchObject(new Uint32Array([]));
-  });
-});
-
-describe("sliceByIndex", () => {
-  test("Array", () => {
-    expect(sliceByIndex([0, 1, 2, 3, 4], [0, 1, 2])).toMatchObject([0, 1, 2]);
-    expect(sliceByIndex([0, 1, 2, 3, 4], [2, 1, 0])).toMatchObject([2, 1, 0]);
-    expect(sliceByIndex([0, 1, 2, 3, 4], [])).toMatchObject([]);
-    expect(sliceByIndex([], [])).toMatchObject([]);
-  });
-
-  test("Uint32Array", () => {
-    expect(
-      sliceByIndex([0, 1, 2, 3, 4], new Uint32Array([0, 1, 2]))
-    ).toMatchObject([0, 1, 2]);
-    expect(
-      sliceByIndex([0, 1, 2, 3, 4], new Uint32Array([2, 1, 0]))
-    ).toMatchObject([2, 1, 0]);
-    expect(sliceByIndex([0, 1, 2, 3, 4], new Uint32Array([]))).toMatchObject(
-      []
-    );
-    expect(sliceByIndex([], new Uint32Array([]))).toMatchObject([]);
-
-    expect(
-      sliceByIndex(new Uint32Array([0, 1, 2, 3, 4]), new Uint32Array([0, 1, 2]))
-    ).toMatchObject(new Uint32Array([0, 1, 2]));
-    expect(
-      sliceByIndex(new Uint32Array([0, 1, 2, 3, 4]), new Uint32Array([2, 1, 0]))
-    ).toMatchObject(new Uint32Array([2, 1, 0]));
-    expect(
-      sliceByIndex(
-        new Uint32Array([0, 1, 2, 3, 4]),
-        new Uint32Array(new Uint32Array([]))
-      )
-    ).toMatchObject(new Uint32Array([]));
-    expect(
-      sliceByIndex(new Uint32Array([]), new Uint32Array([]))
-    ).toMatchObject(new Uint32Array([]));
-  });
-
-  test("Float32Array", () => {
-    expect(
-      sliceByIndex(new Float32Array([0, 1, 2, 3, 4]), [0, 1, 2])
-    ).toMatchObject(new Float32Array([0, 1, 2]));
-    expect(
-      sliceByIndex(new Float32Array([0, 1, 2, 3, 4]), [2, 1, 0])
-    ).toMatchObject(new Float32Array([2, 1, 0]));
-    expect(sliceByIndex(new Float32Array([0, 1, 2, 3, 4]), [])).toMatchObject(
-      new Float32Array([])
-    );
-    expect(sliceByIndex(new Float32Array([]), [])).toMatchObject(
-      new Float32Array([])
-    );
   });
 });
 

--- a/client/src/actions/annotation.ts
+++ b/client/src/actions/annotation.ts
@@ -1,24 +1,23 @@
-/*
-Action creators for user annotation
-*/
+/**
+ * Action creators for user annotation
+ */
 import difference from "lodash.difference";
 import pako from "pako";
 import * as globals from "../globals";
+import { AppDispatch, GetState } from "../reducers";
 import { MatrixFBS, AnnotationsHelpers } from "../util/stateManager";
 
 const { isUserAnnotation } = AnnotationsHelpers;
 
+/**
+ * Add a new user-created category to the obs annotations.
+ * @param newCategoryName - string name for the category.
+ * @param categoryToDuplicate - obs category to use for initial values, or null.
+ * @returns An empty promise.
+ */
 export const annotationCreateCategoryAction =
   (newCategoryName: string, categoryToDuplicate: string) =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  async (dispatch: any, getState: any) => {
-    /*
-  Add a new user-created category to the obs annotations.
-
-  Arguments:
-    newCategoryName - string name for the category.
-    categoryToDuplicate - obs category to use for initial values, or null.
-  */
+  async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
     const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
       getState();
     if (!prevAnnoMatrix || !prevObsCrossfilter) return;
@@ -88,13 +87,12 @@ export const annotationCreateCategoryAction =
     });
   };
 
+/**
+ * Rename a user-created annotation category
+ */
 export const annotationRenameCategoryAction =
   (oldCategoryName: string, newCategoryName: string) =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  (dispatch: any, getState: any) => {
-    /*
-  Rename a user-created annotation category
-  */
+  (dispatch: AppDispatch, getState: GetState): void => {
     const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
       getState();
     if (!prevAnnoMatrix || !prevObsCrossfilter) return;
@@ -122,18 +120,12 @@ export const annotationRenameCategoryAction =
     });
   };
 
+/**
+ * Delete a user-created category
+ */
 export const annotationDeleteCategoryAction =
   (categoryName: string) =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  (
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    dispatch: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    getState: any
-  ) => {
-    /*
-  Delete a user-created category
-  */
+  (dispatch: AppDispatch, getState: GetState): void => {
     const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
       getState();
     if (!prevAnnoMatrix || !prevObsCrossfilter) return;
@@ -149,6 +141,10 @@ export const annotationDeleteCategoryAction =
     });
   };
 
+/**
+ * Add a new label to a user-defined category.  If assignSelected is true, assign
+ * the label to all currently selected cells.
+ */
 export const annotationCreateLabelInCategory =
   (
     categoryName: string,
@@ -156,12 +152,7 @@ export const annotationCreateLabelInCategory =
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     assignSelected: any // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   ) =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  async (dispatch: any, getState: any) => {
-    /*
-  Add a new label to a user-defined category.  If assignSelected is true, assign
-  the label to all currently selected cells.
-  */
+  async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
     const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
       getState();
     if (!prevAnnoMatrix || !prevObsCrossfilter) return;
@@ -190,16 +181,12 @@ export const annotationCreateLabelInCategory =
     });
   };
 
+/**
+ * delete a label from a user-defined category
+ */
 export const annotationDeleteLabelFromCategory =
-  (
-    categoryName: string,
-    labelName: string // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  ) =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  async (dispatch: any, getState: any) => {
-    /*
-    delete a label from a user-defined category
-    */
+  (categoryName: string, labelName: string) =>
+  async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
     const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
       getState();
     if (!prevAnnoMatrix || !prevObsCrossfilter) return;
@@ -221,13 +208,12 @@ export const annotationDeleteLabelFromCategory =
     });
   };
 
+/**
+ * label name change
+ */
 export const annotationRenameLabelInCategory =
   (categoryName: string, oldLabelName: string, newLabelName: string) =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  async (dispatch: any, getState: any) => {
-    /*
-  label name change
-  */
+  async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
     const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
       getState();
     if (!prevAnnoMatrix || !prevObsCrossfilter) return;
@@ -255,13 +241,12 @@ export const annotationRenameLabelInCategory =
     });
   };
 
+/**
+ * set the label on all currently selected
+ */
 export const annotationLabelCurrentSelection =
   (categoryName: string, labelName: string) =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  async (dispatch: any, getState: any) => {
-    /*
-  set the label on all currently selected
-  */
+  async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
     const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
       getState();
     if (!prevAnnoMatrix || !prevObsCrossfilter) return;
@@ -329,19 +314,12 @@ export const needToSaveObsAnnotations = (
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
+/**
+ * Save the user-created obs annotations IF any have changed.
+ */
 export const saveObsAnnotationsAction =
   () =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  async (
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    dispatch: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    getState: any
-  ) => {
-    /*
-  Save the user-created obs annotations IF any have changed.
-  */
+  async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
     const state = getState();
     const { annotations, autosave } = state;
     const { dataCollectionNameIsReadOnly, dataCollectionName } = annotations;
@@ -358,10 +336,9 @@ export const saveObsAnnotationsAction =
       return;
     }
 
-    /*
-  Else, we really do need to save
-  */
-
+    /**
+     * Else, we really do need to save
+     */
     dispatch({
       type: "writable obs annotations - save started",
     });
@@ -408,16 +385,9 @@ export const saveObsAnnotationsAction =
     }
   };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
 export const saveGenesetsAction =
   () =>
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  async (
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    dispatch: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    getState: any
-  ) => {
+  async (dispatch: AppDispatch, getState: GetState): Promise<unknown> => {
     const state = getState();
 
     // bail if gene sets not available, or in readonly mode.

--- a/client/src/actions/annotation.ts
+++ b/client/src/actions/annotation.ts
@@ -8,302 +8,280 @@ import { MatrixFBS, AnnotationsHelpers } from "../util/stateManager";
 
 const { isUserAnnotation } = AnnotationsHelpers;
 
-export const annotationCreateCategoryAction = (
+export const annotationCreateCategoryAction =
+  (newCategoryName: string, categoryToDuplicate: string) =>
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  newCategoryName: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  categoryToDuplicate: any
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-) => async (dispatch: any, getState: any) => {
-  /*
+  async (dispatch: any, getState: any) => {
+    /*
   Add a new user-created category to the obs annotations.
 
   Arguments:
     newCategoryName - string name for the category.
     categoryToDuplicate - obs category to use for initial values, or null.
   */
-  const {
-    annoMatrix: prevAnnoMatrix,
-    obsCrossfilter: prevObsCrossfilter,
-  } = getState();
-  if (!prevAnnoMatrix || !prevObsCrossfilter) return;
-  const { schema } = prevAnnoMatrix;
+    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
+      getState();
+    if (!prevAnnoMatrix || !prevObsCrossfilter) return;
+    const { schema } = prevAnnoMatrix;
 
-  /* name must be a string,  non-zero length */
-  if (typeof newCategoryName !== "string" || newCategoryName.length === 0)
-    throw new Error("user annotations require string name");
+    /* name must be a string,  non-zero length */
+    if (typeof newCategoryName !== "string" || newCategoryName.length === 0)
+      throw new Error("user annotations require string name");
 
-  /* ensure the name isn't already in use! */
-  if (schema.annotations.obsByName[newCategoryName])
-    throw new Error("name collision on annotation category create");
+    /* ensure the name isn't already in use! */
+    if (schema.annotations.obsByName[newCategoryName])
+      throw new Error("name collision on annotation category create");
 
-  let initialValue;
-  let newSchema;
-  let ctor;
-  if (categoryToDuplicate) {
-    /* if we are duplicating a category, retrieve it */
-    const catDupSchema = schema.annotations.obsByName[categoryToDuplicate];
-    const catDupType = catDupSchema?.type;
-    if (catDupType !== "string" && catDupType !== "categorical")
-      throw new Error("categoryToDuplicate does not exist or has invalid type");
+    let initialValue;
+    let newSchema;
+    let ctor;
+    if (categoryToDuplicate) {
+      /* if we are duplicating a category, retrieve it */
+      const catDupSchema = schema.annotations.obsByName[categoryToDuplicate];
+      const catDupType = catDupSchema?.type;
+      if (catDupType !== "string" && catDupType !== "categorical")
+        throw new Error(
+          "categoryToDuplicate does not exist or has invalid type"
+        );
 
-    const catToDupDf = await prevAnnoMatrix
-      .base()
-      .fetch("obs", categoryToDuplicate);
-    const col = catToDupDf.col(categoryToDuplicate);
-    initialValue = col.asArray();
-    const { categories } = col.summarizeCategorical();
-    // all user-created annotations must have the unassigned category
-    if (!categories.includes(globals.unassignedCategoryLabel)) {
-      categories.push(globals.unassignedCategoryLabel);
+      const catToDupDf = await prevAnnoMatrix
+        .base()
+        .fetch("obs", categoryToDuplicate);
+      const col = catToDupDf.col(categoryToDuplicate);
+      initialValue = col.asArray();
+      const { categories } = col.summarizeCategorical();
+      // all user-created annotations must have the unassigned category
+      if (!categories.includes(globals.unassignedCategoryLabel)) {
+        categories.push(globals.unassignedCategoryLabel);
+      }
+      ctor = initialValue.constructor;
+      newSchema = {
+        ...catDupSchema,
+        name: newCategoryName,
+        categories,
+        writable: true,
+      };
+    } else {
+      /* else assign to the standard default value */
+      initialValue = globals.unassignedCategoryLabel;
+      ctor = Array;
+      newSchema = {
+        name: newCategoryName,
+        type: "categorical",
+        categories: [globals.unassignedCategoryLabel],
+        writable: true,
+      };
     }
-    ctor = initialValue.constructor;
-    newSchema = {
-      ...catDupSchema,
-      name: newCategoryName,
-      categories,
-      writable: true,
-    };
-  } else {
-    /* else assign to the standard default value */
-    initialValue = globals.unassignedCategoryLabel;
-    ctor = Array;
-    newSchema = {
-      name: newCategoryName,
-      type: "categorical",
-      categories: [globals.unassignedCategoryLabel],
-      writable: true,
-    };
-  }
 
-  const obsCrossfilter = prevObsCrossfilter.addObsColumn(
-    newSchema,
-    ctor,
-    initialValue
-  );
+    const obsCrossfilter = prevObsCrossfilter.addObsColumn(
+      newSchema,
+      ctor,
+      initialValue
+    );
 
-  dispatch({
-    type: "annotation: create category",
-    data: newCategoryName,
-    categoryToDuplicate,
-    annoMatrix: obsCrossfilter.annoMatrix,
-    obsCrossfilter,
-  });
-};
+    dispatch({
+      type: "annotation: create category",
+      data: newCategoryName,
+      categoryToDuplicate,
+      annoMatrix: obsCrossfilter.annoMatrix,
+      obsCrossfilter,
+    });
+  };
 
-export const annotationRenameCategoryAction = (
+export const annotationRenameCategoryAction =
+  (oldCategoryName: string, newCategoryName: string) =>
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  oldCategoryName: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  newCategoryName: any
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-) => (dispatch: any, getState: any) => {
-  /*
+  (dispatch: any, getState: any) => {
+    /*
   Rename a user-created annotation category
   */
-  const {
-    annoMatrix: prevAnnoMatrix,
-    obsCrossfilter: prevObsCrossfilter,
-  } = getState();
-  if (!prevAnnoMatrix || !prevObsCrossfilter) return;
-  if (!isUserAnnotation(prevAnnoMatrix, oldCategoryName))
-    throw new Error("not a user annotation");
+    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
+      getState();
+    if (!prevAnnoMatrix || !prevObsCrossfilter) return;
+    if (!isUserAnnotation(prevAnnoMatrix, oldCategoryName))
+      throw new Error("not a user annotation");
 
-  /* name must be a string,  non-zero length */
-  if (typeof newCategoryName !== "string" || newCategoryName.length === 0)
-    throw new Error("user annotations require string name");
+    /* name must be a string,  non-zero length */
+    if (typeof newCategoryName !== "string" || newCategoryName.length === 0)
+      throw new Error("user annotations require string name");
 
-  if (oldCategoryName === newCategoryName) return;
+    if (oldCategoryName === newCategoryName) return;
 
-  const obsCrossfilter = prevObsCrossfilter.renameObsColumn(
-    oldCategoryName,
-    newCategoryName
-  );
+    const obsCrossfilter = prevObsCrossfilter.renameObsColumn(
+      oldCategoryName,
+      newCategoryName
+    );
 
-  dispatch({
-    type: "annotation: category edited",
-    annoMatrix: obsCrossfilter.annoMatrix,
-    obsCrossfilter,
-    metadataField: oldCategoryName,
-    newCategoryText: newCategoryName,
-    data: newCategoryName,
-  });
-};
+    dispatch({
+      type: "annotation: category edited",
+      annoMatrix: obsCrossfilter.annoMatrix,
+      obsCrossfilter,
+      metadataField: oldCategoryName,
+      newCategoryText: newCategoryName,
+      data: newCategoryName,
+    });
+  };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export const annotationDeleteCategoryAction = (categoryName: any) => (
+export const annotationDeleteCategoryAction =
+  (categoryName: string) =>
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  dispatch: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  getState: any
-) => {
-  /*
+  (
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    dispatch: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    getState: any
+  ) => {
+    /*
   Delete a user-created category
   */
-  const {
-    annoMatrix: prevAnnoMatrix,
-    obsCrossfilter: prevObsCrossfilter,
-  } = getState();
-  if (!prevAnnoMatrix || !prevObsCrossfilter) return;
-  if (!isUserAnnotation(prevAnnoMatrix, categoryName))
-    throw new Error("not a user annotation");
+    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
+      getState();
+    if (!prevAnnoMatrix || !prevObsCrossfilter) return;
+    if (!isUserAnnotation(prevAnnoMatrix, categoryName))
+      throw new Error("not a user annotation");
 
-  const obsCrossfilter = prevObsCrossfilter.dropObsColumn(categoryName);
-  dispatch({
-    type: "annotation: delete category",
-    annoMatrix: obsCrossfilter.annoMatrix,
-    obsCrossfilter,
-    metadataField: categoryName,
-  });
-};
+    const obsCrossfilter = prevObsCrossfilter.dropObsColumn(categoryName);
+    dispatch({
+      type: "annotation: delete category",
+      annoMatrix: obsCrossfilter.annoMatrix,
+      obsCrossfilter,
+      metadataField: categoryName,
+    });
+  };
 
-export const annotationCreateLabelInCategory = (
+export const annotationCreateLabelInCategory =
+  (
+    categoryName: string,
+    labelName: string,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    assignSelected: any // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  ) =>
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  categoryName: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  labelName: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  assignSelected: any // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-) => async (dispatch: any, getState: any) => {
-  /*
+  async (dispatch: any, getState: any) => {
+    /*
   Add a new label to a user-defined category.  If assignSelected is true, assign
   the label to all currently selected cells.
   */
-  const {
-    annoMatrix: prevAnnoMatrix,
-    obsCrossfilter: prevObsCrossfilter,
-  } = getState();
-  if (!prevAnnoMatrix || !prevObsCrossfilter) return;
-  if (!isUserAnnotation(prevAnnoMatrix, categoryName))
-    throw new Error("not a user annotation");
+    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
+      getState();
+    if (!prevAnnoMatrix || !prevObsCrossfilter) return;
+    if (!isUserAnnotation(prevAnnoMatrix, categoryName))
+      throw new Error("not a user annotation");
 
-  let obsCrossfilter = prevObsCrossfilter.addObsAnnoCategory(
-    categoryName,
-    labelName
-  );
-  if (assignSelected) {
-    obsCrossfilter = await obsCrossfilter.setObsColumnValues(
+    let obsCrossfilter = prevObsCrossfilter.addObsAnnoCategory(
+      categoryName,
+      labelName
+    );
+    if (assignSelected) {
+      obsCrossfilter = await obsCrossfilter.setObsColumnValues(
+        categoryName,
+        prevObsCrossfilter.allSelectedLabels(),
+        labelName
+      );
+    }
+
+    dispatch({
+      type: "annotation: add new label to category",
+      annoMatrix: obsCrossfilter.annoMatrix,
+      obsCrossfilter,
+      metadataField: categoryName,
+      newLabelText: labelName,
+      assignSelectedCells: assignSelected,
+    });
+  };
+
+export const annotationDeleteLabelFromCategory =
+  (
+    categoryName: string,
+    labelName: string // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  ) =>
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  async (dispatch: any, getState: any) => {
+    /*
+    delete a label from a user-defined category
+    */
+    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
+      getState();
+    if (!prevAnnoMatrix || !prevObsCrossfilter) return;
+    if (!isUserAnnotation(prevAnnoMatrix, categoryName))
+      throw new Error("not a user annotation");
+
+    const obsCrossfilter = await prevObsCrossfilter.removeObsAnnoCategory(
+      categoryName,
+      labelName,
+      globals.unassignedCategoryLabel
+    );
+
+    dispatch({
+      type: "annotation: delete label",
+      metadataField: categoryName,
+      label: labelName,
+      annoMatrix: obsCrossfilter.annoMatrix,
+      obsCrossfilter,
+    });
+  };
+
+export const annotationRenameLabelInCategory =
+  (categoryName: string, oldLabelName: string, newLabelName: string) =>
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  async (dispatch: any, getState: any) => {
+    /*
+  label name change
+  */
+    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
+      getState();
+    if (!prevAnnoMatrix || !prevObsCrossfilter) return;
+    if (!isUserAnnotation(prevAnnoMatrix, categoryName))
+      throw new Error("not a user annotation");
+
+    let obsCrossfilter = await prevObsCrossfilter.resetObsColumnValues(
+      categoryName,
+      oldLabelName,
+      newLabelName
+    );
+    obsCrossfilter = await obsCrossfilter.removeObsAnnoCategory(
+      categoryName,
+      oldLabelName,
+      globals.unassignedCategoryLabel
+    );
+
+    dispatch({
+      type: "annotation: label edited",
+      editedLabel: newLabelName,
+      metadataField: categoryName,
+      label: oldLabelName,
+      annoMatrix: obsCrossfilter.annoMatrix,
+      obsCrossfilter,
+    });
+  };
+
+export const annotationLabelCurrentSelection =
+  (categoryName: string, labelName: string) =>
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  async (dispatch: any, getState: any) => {
+    /*
+  set the label on all currently selected
+  */
+    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevObsCrossfilter } =
+      getState();
+    if (!prevAnnoMatrix || !prevObsCrossfilter) return;
+    if (!isUserAnnotation(prevAnnoMatrix, categoryName))
+      throw new Error("not a user annotation");
+
+    const obsCrossfilter = await prevObsCrossfilter.setObsColumnValues(
       categoryName,
       prevObsCrossfilter.allSelectedLabels(),
       labelName
     );
-  }
 
-  dispatch({
-    type: "annotation: add new label to category",
-    annoMatrix: obsCrossfilter.annoMatrix,
-    obsCrossfilter,
-    metadataField: categoryName,
-    newLabelText: labelName,
-    assignSelectedCells: assignSelected,
-  });
-};
-
-export const annotationDeleteLabelFromCategory = (
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  categoryName: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  labelName: any // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-) => async (dispatch: any, getState: any) => {
-  /*
-  delete a label from a user-defined category
-  */
-  const {
-    annoMatrix: prevAnnoMatrix,
-    obsCrossfilter: prevObsCrossfilter,
-  } = getState();
-  if (!prevAnnoMatrix || !prevObsCrossfilter) return;
-  if (!isUserAnnotation(prevAnnoMatrix, categoryName))
-    throw new Error("not a user annotation");
-
-  const obsCrossfilter = await prevObsCrossfilter.removeObsAnnoCategory(
-    categoryName,
-    labelName,
-    globals.unassignedCategoryLabel
-  );
-
-  dispatch({
-    type: "annotation: delete label",
-    metadataField: categoryName,
-    label: labelName,
-    annoMatrix: obsCrossfilter.annoMatrix,
-    obsCrossfilter,
-  });
-};
-
-export const annotationRenameLabelInCategory = (
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  categoryName: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  oldLabelName: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  newLabelName: any
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-) => async (dispatch: any, getState: any) => {
-  /*
-  label name change
-  */
-  const {
-    annoMatrix: prevAnnoMatrix,
-    obsCrossfilter: prevObsCrossfilter,
-  } = getState();
-  if (!prevAnnoMatrix || !prevObsCrossfilter) return;
-  if (!isUserAnnotation(prevAnnoMatrix, categoryName))
-    throw new Error("not a user annotation");
-
-  let obsCrossfilter = await prevObsCrossfilter.resetObsColumnValues(
-    categoryName,
-    oldLabelName,
-    newLabelName
-  );
-  obsCrossfilter = await obsCrossfilter.removeObsAnnoCategory(
-    categoryName,
-    oldLabelName,
-    globals.unassignedCategoryLabel
-  );
-
-  dispatch({
-    type: "annotation: label edited",
-    editedLabel: newLabelName,
-    metadataField: categoryName,
-    label: oldLabelName,
-    annoMatrix: obsCrossfilter.annoMatrix,
-    obsCrossfilter,
-  });
-};
-
-export const annotationLabelCurrentSelection = (
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  categoryName: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  labelName: any
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-) => async (dispatch: any, getState: any) => {
-  /*
-  set the label on all currently selected
-  */
-  const {
-    annoMatrix: prevAnnoMatrix,
-    obsCrossfilter: prevObsCrossfilter,
-  } = getState();
-  if (!prevAnnoMatrix || !prevObsCrossfilter) return;
-  if (!isUserAnnotation(prevAnnoMatrix, categoryName))
-    throw new Error("not a user annotation");
-
-  const obsCrossfilter = await prevObsCrossfilter.setObsColumnValues(
-    categoryName,
-    prevObsCrossfilter.allSelectedLabels(),
-    labelName
-  );
-
-  dispatch({
-    type: "annotation: label current cell selection",
-    metadataField: categoryName,
-    label: labelName,
-    obsCrossfilter,
-    annoMatrix: obsCrossfilter.annoMatrix,
-  });
-};
+    dispatch({
+      type: "annotation: label current cell selection",
+      metadataField: categoryName,
+      label: labelName,
+      obsCrossfilter,
+      annoMatrix: obsCrossfilter.annoMatrix,
+    });
+  };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 function writableAnnotations(annoMatrix: any) {
@@ -352,179 +330,183 @@ export const needToSaveObsAnnotations = (
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export const saveObsAnnotationsAction = () => async (
+export const saveObsAnnotationsAction =
+  () =>
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  dispatch: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  getState: any
-) => {
-  /*
+  async (
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    dispatch: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    getState: any
+  ) => {
+    /*
   Save the user-created obs annotations IF any have changed.
   */
-  const state = getState();
-  const { annotations, autosave } = state;
-  const { dataCollectionNameIsReadOnly, dataCollectionName } = annotations;
-  const { lastSavedAnnoMatrix, saveInProgress } = autosave;
+    const state = getState();
+    const { annotations, autosave } = state;
+    const { dataCollectionNameIsReadOnly, dataCollectionName } = annotations;
+    const { lastSavedAnnoMatrix, saveInProgress } = autosave;
 
-  const annoMatrix = state.annoMatrix.base();
+    const annoMatrix = state.annoMatrix.base();
 
-  if (saveInProgress || annoMatrix === lastSavedAnnoMatrix) return;
-  if (!needToSaveObsAnnotations(annoMatrix, lastSavedAnnoMatrix)) {
-    dispatch({
-      type: "writable obs annotations - save complete",
-      lastSavedAnnoMatrix: annoMatrix,
-    });
-    return;
-  }
-
-  /*
-  Else, we really do need to save
-  */
-
-  dispatch({
-    type: "writable obs annotations - save started",
-  });
-
-  const df = await annoMatrix.fetch("obs", writableAnnotations(annoMatrix));
-  const matrix = MatrixFBS.encodeMatrixFBS(df);
-  const compressedMatrix = pako.deflate(matrix);
-  try {
-    const queryString =
-      !dataCollectionNameIsReadOnly && !!dataCollectionName
-        ? `?annotation-collection-name=${encodeURIComponent(
-            dataCollectionName
-          )}`
-        : "";
-    const res = await fetch(
-      `${globals.API.prefix}${globals.API.version}annotations/obs${queryString}`,
-      {
-        method: "PUT",
-        body: compressedMatrix,
-        headers: new Headers({
-          "Content-Type": "application/octet-stream",
-        }),
-        credentials: "include",
-      }
-    );
-    if (res.ok) {
+    if (saveInProgress || annoMatrix === lastSavedAnnoMatrix) return;
+    if (!needToSaveObsAnnotations(annoMatrix, lastSavedAnnoMatrix)) {
       dispatch({
         type: "writable obs annotations - save complete",
         lastSavedAnnoMatrix: annoMatrix,
       });
-    } else {
+      return;
+    }
+
+    /*
+  Else, we really do need to save
+  */
+
+    dispatch({
+      type: "writable obs annotations - save started",
+    });
+
+    const df = await annoMatrix.fetch("obs", writableAnnotations(annoMatrix));
+    const matrix = MatrixFBS.encodeMatrixFBS(df);
+    const compressedMatrix = pako.deflate(matrix);
+    try {
+      const queryString =
+        !dataCollectionNameIsReadOnly && !!dataCollectionName
+          ? `?annotation-collection-name=${encodeURIComponent(
+              dataCollectionName
+            )}`
+          : "";
+      const res = await fetch(
+        `${globals.API.prefix}${globals.API.version}annotations/obs${queryString}`,
+        {
+          method: "PUT",
+          body: compressedMatrix,
+          headers: new Headers({
+            "Content-Type": "application/octet-stream",
+          }),
+          credentials: "include",
+        }
+      );
+      if (res.ok) {
+        dispatch({
+          type: "writable obs annotations - save complete",
+          lastSavedAnnoMatrix: annoMatrix,
+        });
+      } else {
+        dispatch({
+          type: "writable obs annotations - save error",
+          message: `HTTP error ${res.status} - ${res.statusText}`,
+          res,
+        });
+      }
+    } catch (error) {
       dispatch({
         type: "writable obs annotations - save error",
-        message: `HTTP error ${res.status} - ${res.statusText}`,
-        res,
+        message: error.toString(),
+        error,
       });
     }
-  } catch (error) {
-    dispatch({
-      type: "writable obs annotations - save error",
-      message: error.toString(),
-      error,
-    });
-  }
-};
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export const saveGenesetsAction = () => async (
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  dispatch: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  getState: any
-) => {
-  const state = getState();
-
-  // bail if gene sets not available, or in readonly mode.
-  const { config } = state;
-  const { lastTid, genesets } = state.genesets;
-
-  const genesetsAreAvailable =
-    config?.parameters?.annotations_genesets ?? false;
-  const genesetsReadonly =
-    config?.parameters?.annotations_genesets_readonly ?? true;
-  if (!genesetsAreAvailable || genesetsReadonly) {
-    // our non-save was completed!
-    return dispatch({
-      type: "autosave: genesets complete",
-      lastSavedGenesets: genesets,
-    });
-  }
-
-  dispatch({
-    type: "autosave: genesets started",
-  });
-
-  /* Create the JSON OTA data structure */
-  const tid = (lastTid ?? 0) + 1;
-  const genesetsOTA = [];
-  for (const [name, gs] of genesets) {
-    const genes = [];
-    for (const g of gs.genes.values()) {
-      genes.push({
-        gene_symbol: g.geneSymbol,
-        gene_description: g.geneDescription,
-      });
-    }
-    genesetsOTA.push({
-      geneset_name: name,
-      geneset_description: gs.genesetDescription,
-      genes,
-    });
-  }
-  const ota = {
-    tid,
-    genesets: genesetsOTA,
   };
 
-  /* Save to server */
-  try {
-    const {
-      dataCollectionNameIsReadOnly,
-      dataCollectionName,
-    } = state.annotations;
-    const queryString =
-      !dataCollectionNameIsReadOnly && !!dataCollectionName
-        ? `?annotation-collection-name=${encodeURIComponent(
-            dataCollectionName
-          )}`
-        : "";
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
+export const saveGenesetsAction =
+  () =>
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  async (
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    dispatch: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+    getState: any
+  ) => {
+    const state = getState();
 
-    const res = await fetch(
-      `${globals.API.prefix}${globals.API.version}genesets${queryString}`,
-      {
-        method: "PUT",
-        headers: new Headers({
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        }),
-        body: JSON.stringify(ota),
-        credentials: "include",
-      }
-    );
-    if (!res.ok) {
+    // bail if gene sets not available, or in readonly mode.
+    const { config } = state;
+    const { lastTid, genesets } = state.genesets;
+
+    const genesetsAreAvailable =
+      config?.parameters?.annotations_genesets ?? false;
+    const genesetsReadonly =
+      config?.parameters?.annotations_genesets_readonly ?? true;
+    if (!genesetsAreAvailable || genesetsReadonly) {
+      // our non-save was completed!
       return dispatch({
-        type: "autosave: genesets error",
-        message: `HTTP error ${res.status} - ${res.statusText}`,
-        res,
-      });
-    }
-    return await Promise.all([
-      dispatch({
         type: "autosave: genesets complete",
         lastSavedGenesets: genesets,
-      }),
-      dispatch({
-        type: "geneset: set tid",
-        tid,
-      }),
-    ]);
-  } catch (error) {
-    return dispatch({
-      type: "autosave: genesets error",
-      message: error.toString(),
-      error,
+      });
+    }
+
+    dispatch({
+      type: "autosave: genesets started",
     });
-  }
-};
+
+    /* Create the JSON OTA data structure */
+    const tid = (lastTid ?? 0) + 1;
+    const genesetsOTA = [];
+    for (const [name, gs] of genesets) {
+      const genes = [];
+      for (const g of gs.genes.values()) {
+        genes.push({
+          gene_symbol: g.geneSymbol,
+          gene_description: g.geneDescription,
+        });
+      }
+      genesetsOTA.push({
+        geneset_name: name,
+        geneset_description: gs.genesetDescription,
+        genes,
+      });
+    }
+    const ota = {
+      tid,
+      genesets: genesetsOTA,
+    };
+
+    /* Save to server */
+    try {
+      const { dataCollectionNameIsReadOnly, dataCollectionName } =
+        state.annotations;
+      const queryString =
+        !dataCollectionNameIsReadOnly && !!dataCollectionName
+          ? `?annotation-collection-name=${encodeURIComponent(
+              dataCollectionName
+            )}`
+          : "";
+
+      const res = await fetch(
+        `${globals.API.prefix}${globals.API.version}genesets${queryString}`,
+        {
+          method: "PUT",
+          headers: new Headers({
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          }),
+          body: JSON.stringify(ota),
+          credentials: "include",
+        }
+      );
+      if (!res.ok) {
+        return dispatch({
+          type: "autosave: genesets error",
+          message: `HTTP error ${res.status} - ${res.statusText}`,
+          res,
+        });
+      }
+      return await Promise.all([
+        dispatch({
+          type: "autosave: genesets complete",
+          lastSavedGenesets: genesets,
+        }),
+        dispatch({
+          type: "geneset: set tid",
+          tid,
+        }),
+      ]);
+    } catch (error) {
+      return dispatch({
+        type: "autosave: genesets error",
+        message: error.toString(),
+        error,
+      });
+    }
+  };

--- a/client/src/actions/embedding.ts
+++ b/client/src/actions/embedding.ts
@@ -5,7 +5,7 @@ action creators related to embeddings choice
 import { Action, ActionCreator } from "redux";
 import { ThunkAction } from "redux-thunk";
 import { AnnoMatrixObsCrossfilter } from "../annoMatrix";
-import type { AppDispatch, RootState } from "../reducers";
+import type { AppDispatch, GetState, RootState } from "../reducers";
 import { _setEmbeddingSubset } from "../util/stateManager/viewStackHelpers";
 import { Field } from "../common/types/schema";
 
@@ -37,24 +37,22 @@ export const layoutChoiceAction: ActionCreator<
   ThunkAction<Promise<void>, RootState, never, Action<"set layout choice">>
 > =
   (newLayoutChoice: string) =>
-  async (dispatch: AppDispatch, getState: () => RootState): Promise<void> => {
+  async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
     /*
   On layout choice, make sure we have selected all on the previous layout, AND the new
   layout.
   */
-  const {
-    annoMatrix: prevAnnoMatrix,
-    obsCrossfilter: prevCrossfilter,
-  } = getState();
-  const [annoMatrix, obsCrossfilter] = await _switchEmbedding(
-    prevAnnoMatrix,
-    prevCrossfilter,
-    newLayoutChoice
-  );
-  dispatch({
-    type: "set layout choice",
-    layoutChoice: newLayoutChoice,
-    obsCrossfilter,
-    annoMatrix,
-  });
-};
+    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevCrossfilter } =
+      getState();
+    const [annoMatrix, obsCrossfilter] = await _switchEmbedding(
+      prevAnnoMatrix,
+      prevCrossfilter,
+      newLayoutChoice
+    );
+    dispatch({
+      type: "set layout choice",
+      layoutChoice: newLayoutChoice,
+      obsCrossfilter,
+      annoMatrix,
+    });
+  };

--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -12,7 +12,7 @@ import * as annoActions from "./annotation";
 import * as viewActions from "./viewStack";
 import * as embActions from "./embedding";
 import * as genesetActions from "./geneset";
-import { AppDispatch, RootState } from "../reducers";
+import { AppDispatch, GetState } from "../reducers";
 import { EmbeddingSchema, Schema } from "../common/types/schema";
 import { UserInfoPayload } from "../reducers/userInfo";
 
@@ -109,7 +109,7 @@ Application bootstrap
 */
 const doInitialDataLoad = (): ((
   dispatch: AppDispatch,
-  getState: () => RootState
+  getState: GetState
 ) => void) =>
   catchErrorsWrap(async (dispatch: AppDispatch) => {
     dispatch({ type: "initial data load start" });

--- a/client/src/annoMatrix/crossfilter.ts
+++ b/client/src/annoMatrix/crossfilter.ts
@@ -8,6 +8,7 @@ AnnoMatrix stay in sync:
     between Crossfilter and AnnoMatrix.
 */
 import Crossfilter, {
+  CrossfilterSelector,
   CrossfilterDimensionParameters,
 } from "../util/typedCrossfilter";
 import { _getColumnSchema } from "./schema";
@@ -76,7 +77,7 @@ export default class AnnoMatrixObsCrossfilter {
     return new AnnoMatrixObsCrossfilter(annoMatrix, obsCrossfilter);
   }
 
-  dropObsColumn(col: LabelType): AnnoMatrixObsCrossfilter {
+  dropObsColumn(col: string): AnnoMatrixObsCrossfilter {
     const annoMatrix = this.annoMatrix.dropObsColumn(col);
     let { obsCrossfilter } = this;
     const dimName = _dimensionName(Field.obs, col);
@@ -86,10 +87,7 @@ export default class AnnoMatrixObsCrossfilter {
     return new AnnoMatrixObsCrossfilter(annoMatrix, obsCrossfilter);
   }
 
-  renameObsColumn(
-    oldCol: LabelType,
-    newCol: LabelType
-  ): AnnoMatrixObsCrossfilter {
+  renameObsColumn(oldCol: string, newCol: string): AnnoMatrixObsCrossfilter {
     const annoMatrix = this.annoMatrix.renameObsColumn(oldCol, newCol);
     const oldDimName = _dimensionName(Field.obs, oldCol);
     const newDimName = _dimensionName(Field.obs, newCol);
@@ -100,10 +98,7 @@ export default class AnnoMatrixObsCrossfilter {
     return new AnnoMatrixObsCrossfilter(annoMatrix, obsCrossfilter);
   }
 
-  addObsAnnoCategory(
-    col: LabelType,
-    category: string
-  ): AnnoMatrixObsCrossfilter {
+  addObsAnnoCategory(col: string, category: string): AnnoMatrixObsCrossfilter {
     const annoMatrix = this.annoMatrix.addObsAnnoCategory(col, category);
     const dimName = _dimensionName(Field.obs, col);
     let { obsCrossfilter } = this;
@@ -114,7 +109,7 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   async removeObsAnnoCategory(
-    col: LabelType,
+    col: string,
     category: string,
     unassignedCategory: string
   ): Promise<AnnoMatrixObsCrossfilter> {
@@ -132,7 +127,7 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   async setObsColumnValues(
-    col: LabelType,
+    col: string,
     rowLabels: Int32Array,
     value: DataframeValue
   ): Promise<AnnoMatrixObsCrossfilter> {
@@ -150,7 +145,7 @@ export default class AnnoMatrixObsCrossfilter {
   }
 
   async resetObsColumnValues<T extends DataframeValue>(
-    col: LabelType,
+    col: string,
     oldValue: T,
     newValue: T
   ): Promise<AnnoMatrixObsCrossfilter> {
@@ -200,8 +195,7 @@ export default class AnnoMatrixObsCrossfilter {
   async select(
     field: Field,
     query: Query,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- TODO revisit: waiting for typings from util/typedCrossfilter
-    spec: any
+    spec: CrossfilterSelector
   ): Promise<AnnoMatrixObsCrossfilter> {
     const { annoMatrix } = this;
     let { obsCrossfilter } = this;
@@ -289,9 +283,8 @@ export default class AnnoMatrixObsCrossfilter {
       this.obsCrossfilter.size() === 0 ||
       this.obsCrossfilter.dimensionNames().length === 0
     ) {
-      // @ts-expect-error ts-migrate --- TODO revisit:
-      // Type 'Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array' is not assignable to type 'A'...
-      return array.fill(selectedValue);
+      array.fill(selectedValue);
+      return array;
     }
     return this.obsCrossfilter.fillByIsSelected(
       array,
@@ -342,9 +335,7 @@ export default class AnnoMatrixObsCrossfilter {
 
     /* assumed to be 1D */
     const col = df.icol(0);
-    const colName = df.colIndex.getLabel(0);
-    // @ts-expect-error --- TODO revisit:
-    // `colName` Argument of type 'LabelType | undefined' is not assignable to parameter of type 'LabelType'. Type 'undefined' is not assignable to type 'LabelType'.
+    const colName: LabelType = df.colIndex.getLabel(0) as LabelType;
     const type = this._getColumnBaseType(field, colName);
     if (type === "string" || type === "categorical" || type === "boolean") {
       return { type: "enum", value: col.asArray() };

--- a/client/src/annoMatrix/fetchHelpers.ts
+++ b/client/src/annoMatrix/fetchHelpers.ts
@@ -4,25 +4,3 @@ export { doBinaryRequest, doFetch } from "../util/actionHelpers";
 export function _dubEncURIComp(s: string | number | boolean): string {
   return encodeURIComponent(encodeURIComponent(s));
 }
-
-/* currently unused, consider deleting */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function _fetchResult(promise: any) {
-  let _status = "pending";
-  const res = promise.then(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-    (r: any) => {
-      _status = "success";
-      return r;
-    },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-    (e: any) => {
-      _status = "error";
-      throw e;
-    }
-  );
-
-  res.status = () => _status;
-
-  return res;
-}

--- a/client/src/annoMatrix/normalize.ts
+++ b/client/src/annoMatrix/normalize.ts
@@ -11,6 +11,7 @@ import {
   ArraySchema,
   Field,
   Schema,
+  Category,
 } from "../common/types/schema";
 
 export function normalizeResponse(
@@ -91,7 +92,7 @@ export function normalizeWritableCategoricalSchema(
   the categories array contains all unique values in the data array, AND that
   the array is UI sorted.
   */
-  const categorySet = new Set<string>(
+  const categorySet = new Set<Category>(
     col.summarizeCategorical().categories.concat(colSchema.categories ?? [])
   );
   if (!categorySet.has(unassignedCategoryLabel)) {
@@ -125,7 +126,7 @@ export function normalizeCategorical(
 
   // consolidate all categories from data and schema into a single list
   const colDataSummary = col.summarizeCategorical();
-  const allCategories = new Set<string>(
+  const allCategories = new Set<Category>(
     colDataSummary.categories.concat(colSchema.categories ?? [])
   );
 

--- a/client/src/annoMatrix/normalize.ts
+++ b/client/src/annoMatrix/normalize.ts
@@ -84,7 +84,7 @@ function castColumnToBoolean(df: Dataframe, label: LabelType): Dataframe {
 }
 
 export function normalizeWritableCategoricalSchema(
-  colSchema: AnnotationColumnSchema, // eslint-disable-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  colSchema: AnnotationColumnSchema,
   col: DataframeColumn
 ): ArraySchema {
   /*

--- a/client/src/annoMatrix/schema.ts
+++ b/client/src/annoMatrix/schema.ts
@@ -7,7 +7,7 @@ import {
   Field,
   Schema,
 } from "../common/types/schema";
-import { LabelArray, LabelType } from "../util/dataframe/types";
+import { LabelType } from "../util/dataframe/types";
 
 export function _getColumnSchema(
   schema: Schema,
@@ -48,7 +48,7 @@ export function _getColumnDimensionNames(
   schema: Schema,
   field: Field,
   col: LabelType
-): LabelArray | undefined {
+): LabelType[] | undefined {
   /*
 		field/col may be an alias for multiple columns. Currently used to map ND 
 		values to 1D dataframe columns for embeddings/layout. Signified by the presence

--- a/client/src/annoMatrix/views.ts
+++ b/client/src/annoMatrix/views.ts
@@ -21,6 +21,7 @@ import {
   EmbeddingSchema,
 } from "../common/types/schema";
 import { LabelIndexBase } from "../util/dataframe/labelIndex";
+import { isTypedArray } from "../common/types/arraytypes";
 
 type MapFn = (
   field: Field,
@@ -232,7 +233,7 @@ function _clipAnnoMatrix(
 ): DataframeValueArray {
   /* only clip obs and var scalar columns */
   if (field !== Field.obs && field !== Field.X) return colData;
-  if (!_isContinuousType(colSchema)) return colData;
+  if (!_isContinuousType(colSchema) || !isTypedArray(colData)) return colData;
   if (qmin < 0) qmin = 0;
   if (qmax > 1) qmax = 1;
   if (qmin === 0 && qmax === 1) return colData;

--- a/client/src/annoMatrix/views.ts
+++ b/client/src/annoMatrix/views.ts
@@ -39,7 +39,7 @@ abstract class AnnoMatrixView extends AnnoMatrix {
     this.isView = true;
   }
 
-  addObsAnnoCategory(col: LabelType, category: string): AnnoMatrix {
+  addObsAnnoCategory(col: string, category: string): AnnoMatrix {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = this.viewOf.addObsAnnoCategory(col, category);
     newAnnoMatrix.schema = newAnnoMatrix.viewOf.schema;
@@ -47,7 +47,7 @@ abstract class AnnoMatrixView extends AnnoMatrix {
   }
 
   async removeObsAnnoCategory(
-    col: LabelType,
+    col: string,
     category: string,
     unassignedCategory: string
   ): Promise<AnnoMatrix> {
@@ -61,7 +61,7 @@ abstract class AnnoMatrixView extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
-  dropObsColumn(col: LabelType): AnnoMatrix {
+  dropObsColumn(col: string): AnnoMatrix {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = this.viewOf.dropObsColumn(col);
     newAnnoMatrix._cache.obs = this._cache.obs.dropCol(col);
@@ -80,7 +80,7 @@ abstract class AnnoMatrixView extends AnnoMatrix {
     return newAnnoMatrix;
   }
 
-  renameObsColumn(oldCol: LabelType, newCol: LabelType): AnnoMatrix {
+  renameObsColumn(oldCol: string, newCol: string): AnnoMatrix {
     const newAnnoMatrix = this._clone();
     newAnnoMatrix.viewOf = this.viewOf.renameObsColumn(oldCol, newCol);
     newAnnoMatrix.schema = newAnnoMatrix.viewOf.schema;
@@ -88,7 +88,7 @@ abstract class AnnoMatrixView extends AnnoMatrix {
   }
 
   async setObsColumnValues(
-    col: LabelType,
+    col: string,
     rowLabels: Int32Array,
     value: DataframeValue
   ): Promise<AnnoMatrix> {
@@ -104,7 +104,7 @@ abstract class AnnoMatrixView extends AnnoMatrix {
   }
 
   async resetObsColumnValues<T extends DataframeValue>(
-    col: LabelType,
+    col: string,
     oldValue: T,
     newValue: T
   ): Promise<AnnoMatrix> {
@@ -144,13 +144,8 @@ class AnnoMatrixMapView extends AnnoMatrixView {
   ): Promise<[WhereCache | null, Dataframe]> {
     const df = await this.viewOf._fetch(field, query);
     const dfMapped = df.mapColumns(
-      (colData: DataframeValueArray, colIdx: number) => {
-        const colLabel = df.colIndex.getLabel(colIdx);
-        // @ts-expect-error ts-migrate --- TODO revisit:
-        // `colLabel`: Argument of type 'LabelType | undefined' is not assignable to parameter of type 'LabelType'.
+      (colData: DataframeValueArray, _colIdx: number, colLabel: LabelType) => {
         const colSchema = _getColumnSchema(this.schema, field, colLabel);
-        // @ts-expect-error ts-migrate --- TODO revisit:
-        // `colLabel`: Argument of type 'LabelType | undefined' is not assignable to parameter of type 'LabelType'.
         return this.mapFn(field, colLabel, colSchema, colData, df);
       }
     );

--- a/client/src/annoMatrix/whereCache.ts
+++ b/client/src/annoMatrix/whereCache.ts
@@ -51,7 +51,7 @@ creates a cache entry of:
 import { _getColumnDimensionNames } from "./schema";
 import { _hashStringValues, Query } from "./query";
 import { Field, Schema } from "../common/types/schema";
-import { LabelArray } from "../util/dataframe/types";
+import { LabelType, LabelArray } from "../util/dataframe/types";
 
 export interface WhereCache {
   summarize?: {
@@ -67,7 +67,7 @@ export interface WhereCache {
 export type WhereCacheColumnLabels = LabelArray;
 
 interface WhereCacheTerms {
-  [key: string]: Map<string, Map<string, WhereCacheColumnLabels>>;
+  [key: string]: Map<string, Map<string, LabelType[]>>;
 }
 
 export function _whereCacheGet(
@@ -75,7 +75,7 @@ export function _whereCacheGet(
   schema: Schema,
   field: Field,
   query: Query
-): WhereCacheColumnLabels | [undefined] {
+): LabelType[] | [undefined] {
   /* 
 	query will either be an where query (object) or a column name (string).
 
@@ -119,6 +119,10 @@ export function _whereCacheCreate(
 	*/
   if (typeof query !== "object") return null;
 
+  const columnLabelsAsArray: LabelType[] = Array.isArray(columnLabels)
+    ? columnLabels
+    : Array.from(columnLabels);
+
   if ("where" in query) {
     const {
       field: queryField,
@@ -129,7 +133,7 @@ export function _whereCacheCreate(
       where: {
         [field]: {
           [queryField]: new Map([
-            [queryColumn, new Map([[queryValue, columnLabels]])],
+            [queryColumn, new Map([[queryValue, columnLabelsAsArray]])],
           ]),
         },
       },
@@ -148,7 +152,7 @@ export function _whereCacheCreate(
         [field]: {
           [method]: {
             [queryField]: new Map([
-              [queryColumn, new Map([[queryValueHash, columnLabels]])],
+              [queryColumn, new Map([[queryValueHash, columnLabelsAsArray]])],
             ]),
           },
         },

--- a/client/src/common/types/arraytypes.ts
+++ b/client/src/common/types/arraytypes.ts
@@ -16,8 +16,13 @@ export type TypedArray =
   | Float32Array
   | Float64Array;
 
-export type UnsignedTypedArray = Uint8Array | Uint16Array | Uint32Array;
+export type UnsignedIntTypedArray =
+  | Uint8Array
+  | Uint8ClampedArray
+  | Uint16Array
+  | Uint32Array;
 export type FloatTypedArray = Float32Array | Float64Array;
+export type IntTypedArray = Int8Array | Int16Array | Int32Array;
 
 export type TypedArrayConstructor =
   | Int8ArrayConstructor
@@ -29,25 +34,34 @@ export type TypedArrayConstructor =
   | Float32ArrayConstructor
   | Float64ArrayConstructor;
 
+/** this general type is the basis of all data stored in dataframe/crossfilter */
+export type SortableArray = Array<number | string | boolean> | TypedArray;
+
+/** used if you accept array-ish, but don't care about the contents of the object */
 export type AnyArray = Array<unknown> | TypedArray;
 
-export interface GenericArrayConstructor<T extends AnyArray> {
+export interface GenericArrayConstructor<T> {
   new (
     ...args: ConstructorParameters<
       typeof Int8Array &
         typeof Uint8Array &
+        typeof Uint8ClampedArray &
         typeof Int16Array &
         typeof Uint16Array &
         typeof Int32Array &
         typeof Uint32Array &
         typeof Float32Array &
         typeof Float64Array &
-        typeof Array
+        typeof Array &
+        T
     >
   ): T;
 }
 
 export type NumberArray = Array<number> | TypedArray;
+export type NumberArrayConstructor = GenericArrayConstructor<
+  Array<number> | TypedArray
+>;
 
 export type Int8 = Int8Array[0];
 export type Uint8 = Uint8Array[0];
@@ -80,15 +94,31 @@ export function isFloatTypedArray(tbd: unknown): tbd is FloatTypedArray {
 }
 
 /**
- * Test if the paramter is a float TypedArray
+ * Test if the paramter is an unsigned int TypedArray
  * @param tbd - value to be tested
- * @returns - true if `tbd` is a float typed array.
+ * @returns - true if `tbd` is an unsigned int typed array.
  */
-export function isUnsignedTypedArray(tbd: unknown): tbd is UnsignedTypedArray {
+export function isUnsignedIntTypedArray(
+  tbd: unknown
+): tbd is UnsignedIntTypedArray {
   return (
     tbd instanceof Uint8Array ||
+    tbd instanceof Uint8ClampedArray ||
     tbd instanceof Uint16Array ||
     tbd instanceof Uint32Array
+  );
+}
+
+/**
+ * Test if the paramter is an int TypedArray
+ * @param tbd - value to be tested
+ * @returns - true if `tbd` is an int typed array.
+ */
+export function isIntTypedArray(tbd: unknown): tbd is IntTypedArray {
+  return (
+    tbd instanceof Int8Array ||
+    tbd instanceof Int16Array ||
+    tbd instanceof Int32Array
   );
 }
 

--- a/client/src/components/scatterplot/scatterplot.tsx
+++ b/client/src/components/scatterplot/scatterplot.tsx
@@ -298,9 +298,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     );
 
     const colors = this.computePointColors(colorTable.rgb);
-
-    const { colorAccessor } = colorsProp;
-    const colorByData = colorDf?.col(colorAccessor)?.asArray();
+    const colorByData = colorDf?.icol(0)?.asArray();
     const {
       metadataField: pointDilationCategory,
       categoryField: pointDilationLabel,
@@ -380,9 +378,7 @@ class Scatterplot extends React.PureComponent<{}, State> {
     colors: any,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     pointDilation: any
-  ): Promise<
-    [Dataframe, Dataframe, Dataframe | null, Dataframe | null]
-  > {
+  ): Promise<[Dataframe, Dataframe, Dataframe | null, Dataframe | null]> {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix } = this.props;
     const { metadataField: pointDilationAccessor } = pointDilation;

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -67,4 +67,6 @@ export type RootState = ReturnType<typeof store.getState>;
 
 export type AppDispatch = ThunkDispatch<RootState, never, AnyAction>;
 
+export type GetState = () => RootState;
+
 export default store;

--- a/client/src/reducers/userInfo.ts
+++ b/client/src/reducers/userInfo.ts
@@ -1,6 +1,6 @@
 import { Action } from "redux";
 
-export interface UserInfoAction extends Action<string>, User {
+export interface UserInfoAction extends Action<string> {
   userInfo: UserInfoPayload;
   error: string;
 }

--- a/client/src/util/actionHelpers.ts
+++ b/client/src/util/actionHelpers.ts
@@ -1,7 +1,7 @@
 import sortBy from "lodash.sortby";
 /* XXX: cough, cough, ... */
 import { postNetworkErrorToast } from "../components/framework/toasters";
-import type { AppDispatch, RootState } from "../reducers";
+import type { AppDispatch, GetState } from "../reducers";
 
 /*
 dispatch an action error to the user.   Currently we use
@@ -20,10 +20,10 @@ export const dispatchNetworkErrorMessageToUser = (message: string): void => {
 Catch unexpected errors and make sure we don't lose them!
 */
 export function catchErrorsWrap(
-  fn: (dispatch: AppDispatch, getState: () => RootState) => Promise<void>,
+  fn: (dispatch: AppDispatch, getState: GetState) => Promise<void>,
   dispatchToUser = false
 ) {
-  return (dispatch: AppDispatch, getState: () => RootState): void => {
+  return (dispatch: AppDispatch, getState: GetState): void => {
     fn(dispatch, getState).catch((error: Error) => {
       console.error(error);
       if (dispatchToUser) {

--- a/client/src/util/catLabelSort.ts
+++ b/client/src/util/catLabelSort.ts
@@ -10,29 +10,38 @@ TL;DR: sort order is:
 
 import isNumber from "is-number";
 import * as globals from "../globals";
+import { Category } from "../common/types/schema";
 
-function caseInsensitiveCompare(a: string, b: string): number {
+function caseInsensitiveCompare(
+  a: string | number | boolean,
+  b: string | number | boolean
+): number {
   const textA = String(a).toUpperCase();
   const textB = String(b).toUpperCase();
   return textA < textB ? -1 : textA > textB ? 1 : 0;
 }
 
+/** typescript type safety */
+function isNumberForReal(tbd: unknown): tbd is number {
+  return isNumber(tbd);
+}
+
 const catLabelSort = (
   isUserAnno: boolean,
-  values: Array<string>
-): Array<string> => {
+  values: Array<Category>
+): Array<Category> => {
   /* this sort could be memoized for perf */
 
-  const strings: string[] = [];
-  const ints: string[] = [];
-  const unassignedOrNaN: string[] = [];
+  const strings: (string | number | boolean)[] = [];
+  const ints: (string | number | boolean)[] = [];
+  const unassignedOrNaN: (string | number | boolean)[] = [];
 
-  values.forEach((v: string) => {
+  values.forEach((v) => {
     if (isUserAnno && v === globals.unassignedCategoryLabel) {
       unassignedOrNaN.push(v);
     } else if (String(v).toLowerCase() === "nan") {
       unassignedOrNaN.push(v);
-    } else if (isNumber(v)) {
+    } else if (isNumberForReal(v)) {
       ints.push(v);
     } else {
       strings.push(v);

--- a/client/src/util/dataframe/cache.ts
+++ b/client/src/util/dataframe/cache.ts
@@ -14,7 +14,10 @@ import Dataframe from "./dataframe";
 
 function hashDataframe(df: Dataframe): string {
   if (df.isEmpty()) return "";
-  return df.__columnsAccessor.map((c) => c.__id).join(",");
+  return df
+    .columns()
+    .map((c) => c.__id)
+    .join(",");
 }
 
 function noop(df: Dataframe): Dataframe {

--- a/client/src/util/dataframe/dataframe.ts
+++ b/client/src/util/dataframe/dataframe.ts
@@ -301,7 +301,7 @@ class Dataframe {
     get.summarizeCategorical = callOnceLazy(() =>
       _summarizeCategorical(column)
     );
-    get.summarizeContinuous = isContinuous
+    get.summarizeContinuous = isTypedArray(column)
       ? callOnceLazy(() => _summarizeContinuous(column))
       : raiseIsNotContinuous;
 

--- a/client/src/util/dataframe/dataframe.ts
+++ b/client/src/util/dataframe/dataframe.ts
@@ -93,6 +93,7 @@ interface DataframeConstructor {
 export type MapColumnsCallbackFn = (
   data: DataframeValueArray,
   idx: number,
+  lbl: LabelType,
   df: Dataframe
 ) => DataframeValueArray;
 
@@ -103,10 +104,10 @@ function raiseIsNotContinuous<R = void>(): R {
 
 class Dataframe {
   /** @internal */
-  __columns: DataframeValueArray[];
+  private __columns: DataframeValueArray[];
 
   /** @internal */
-  __columnsAccessor: DataframeColumn[] = [];
+  private __columnsAccessor: DataframeColumn[] = [];
 
   __id: string;
 
@@ -168,7 +169,7 @@ class Dataframe {
   }
 
   /** @internal */
-  static __errorChecks(
+  private static __errorChecks(
     dims: [number, number],
     columnarData: AnyArray[],
     rowIndex: LabelIndex,
@@ -212,7 +213,7 @@ class Dataframe {
   }
 
   /** @internal */
-  static __compileColumn(
+  private static __compileColumn(
     column: DataframeValueArray,
     getRowOffset: (label: LabelType) => OffsetType | -1,
     getRowLabel: (offset: number) => LabelType | undefined
@@ -343,7 +344,7 @@ class Dataframe {
   }
 
   /** @internal */
-  __compile(accessors: (DataframeColumn | null)[]): void {
+  private __compile(accessors: (DataframeColumn | null)[]): void {
     /*
     Compile data accessors for each column.
 
@@ -632,7 +633,7 @@ class Dataframe {
   }
 
   /** @internal */
-  __subset(
+  private __subset(
     newRowIndex: LabelIndex | null,
     newColIndex: LabelIndex | null
   ): Dataframe {
@@ -924,7 +925,12 @@ class Dataframe {
     callback MUST not modify the column, but instead return a mutated copy.
     */
     const columns = this.__columns.map((colData, colIdx) =>
-      callback(colData, colIdx, this)
+      callback(
+        colData,
+        colIdx,
+        this.colIndex.getLabel(colIdx) as LabelType,
+        this
+      )
     );
     const columnsAccessor: (DataframeColumn | null)[] = columns.map((c, idx) =>
       this.__columns[idx] === c ? this.__columnsAccessor[idx] : null

--- a/client/src/util/dataframe/index.ts
+++ b/client/src/util/dataframe/index.ts
@@ -8,6 +8,7 @@ export {
 export { default as dataframeMemo } from "./cache";
 export type {
   LabelType,
+  LabelArray,
   DataframeValue,
   DataframeValueArray,
   DataframeColumn,

--- a/client/src/util/dataframe/summarize.ts
+++ b/client/src/util/dataframe/summarize.ts
@@ -6,7 +6,8 @@ of computing quantiles.  Would be good to switch from sort to
 partition at some point.
 */
 import {
-  AnyArray,
+  SortableArray,
+  NumberArray,
   GenericArrayConstructor,
 } from "../../common/types/arraytypes";
 import { ContinuousColumnSummary, CategoricalColumnSummary } from "./types";
@@ -16,7 +17,7 @@ import { sortArray } from "../typedCrossfilter/sort";
 // [ 0, 0.01, 0.02, ..., 1.0]
 const centileNames = new Array(101).fill(0).map((_v, idx) => idx / 100);
 
-export function summarizeContinuous(col: AnyArray): ContinuousColumnSummary {
+export function summarizeContinuous(col: NumberArray): ContinuousColumnSummary {
   let nan = 0;
   let pinf = 0;
   let ninf = 0;
@@ -66,7 +67,9 @@ export function summarizeContinuous(col: AnyArray): ContinuousColumnSummary {
   };
 }
 
-export function summarizeCategorical(col: AnyArray): CategoricalColumnSummary {
+export function summarizeCategorical(
+  col: SortableArray
+): CategoricalColumnSummary {
   const categoryCounts = new Map();
   if (col) {
     for (let r = 0, l = col.length; r < l; r += 1) {

--- a/client/src/util/range.ts
+++ b/client/src/util/range.ts
@@ -22,7 +22,7 @@ rangeFill(array, start, step) -> array
 
 */
 
-import { TypedArray, NumberArray } from "../common/types/arraytypes";
+import { NumberArray } from "../common/types/arraytypes";
 
 function _doFill<T extends NumberArray>(
   arr: T,
@@ -36,7 +36,11 @@ function _doFill<T extends NumberArray>(
   return arr;
 }
 
-export function rangeFill(arr: NumberArray, start = 0, step = 1): NumberArray {
+export function rangeFill<T extends NumberArray>(
+  arr: T,
+  start = 0,
+  step = 1
+): T {
   return _doFill(arr, start, step, arr.length);
 }
 

--- a/client/src/util/typedCrossfilter/bitArray.ts
+++ b/client/src/util/typedCrossfilter/bitArray.ts
@@ -20,15 +20,13 @@ import { Interval } from "./positiveIntervals";
 // The underlying data structure uses TypedArrays for performance.
 //
 class BitArray {
-  bitarray: Int32Array;
+  private bitarray: Int32Array;
 
-  bitmask: Int32Array;
+  private bitmask: Int32Array;
 
-  dimensionCount: number;
+  public length: number;
 
-  length: number;
-
-  width: number;
+  private width: number;
 
   constructor(length: number) {
     // Initially allocate a 32 bit wide array.  allocDimension() will expand
@@ -41,10 +39,8 @@ class BitArray {
     // Fixed for the life of this object.
     this.length = length;
 
-    // Bitarray width.  width is always greater than dimensionCount/32.
+    // Bitarray width.  width is always greater than num dimensions / 32.
     this.width = 1; // underlying number of 32 bit arrays
-    this.dimensionCount = 0; // num allocated dimensions
-
     this.bitmask = new Int32Array(this.width); // dimension allocation mask
     this.bitarray = new Int32Array(this.width * this.length);
     Object.seal(this);
@@ -137,7 +133,6 @@ class BitArray {
       dim = this._findFreeDimension();
     }
 
-    this.dimensionCount += 1;
     return dim;
   }
 
@@ -149,7 +144,6 @@ class BitArray {
     this.deselectAll(dim);
     const col = dim >>> 5;
     this.bitmask[col] &= ~(1 << dim % 32);
-    this.dimensionCount -= 1;
   }
 
   // return true if this index is selected in ALL dimensions.

--- a/client/src/util/typedCrossfilter/bitArray.ts
+++ b/client/src/util/typedCrossfilter/bitArray.ts
@@ -1,5 +1,8 @@
 /* eslint-disable no-bitwise -- crossfilter relies on bitwise ops */
 
+import { TypedArray } from "../../common/types/arraytypes";
+import { Interval } from "./positiveIntervals";
+
 // BitArray is a 2D bitarray with size [length, nBitWidth].
 // Each bit is referred to as a `dimension`.  Dimensions may be
 // dynamically allocated and deallocated.  The overall length
@@ -17,27 +20,21 @@
 // The underlying data structure uses TypedArrays for performance.
 //
 class BitArray {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  bitarray: any;
+  bitarray: Int32Array;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  bitmask: any;
+  bitmask: Int32Array;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  dimensionCount: any;
+  dimensionCount: number;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  length: any;
+  length: number;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  width: any;
+  width: number;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  constructor(length: any) {
+  constructor(length: number) {
     // Initially allocate a 32 bit wide array.  allocDimension() will expand
     // as necessary.
     //
-    // Int32Array is (counterintuitively) used to accomadate JS numeric casting
+    // Int32Array is (counterintuitively) used to accommodate JS numeric casting
     // (to/from primitive number type).
     //
 
@@ -56,15 +53,13 @@ class BitArray {
   // Return the number of records that are selected, ie, have a one bit in
   // all allocated dimensions.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  selectionCount() {
+  selectionCount(): number {
     return this.countAllOnes();
   }
 
   // Count all records that have a 'one' bit in allocated dimensions.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  countAllOnes() {
+  countAllOnes(): number {
     let count = 0;
     const { bitarray, length, width } = this;
     if (width === 1) {
@@ -94,8 +89,7 @@ class BitArray {
 
   // count trailing zeros - hard to do fast in JS!
   // https://en.wikipedia.org/wiki/Find_first_set#CTZ
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  static ctz(av: any) {
+  private static ctz(av: number): number {
     let c = 32;
     let v = av;
     v &= -v; // isolate lowest non-zero bit
@@ -108,10 +102,10 @@ class BitArray {
     return c;
   }
 
-  // find a free dimension.  Return undefined if none
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  _findFreeDimension() {
-    let dim;
+  // find a free dimension.  Return -1 if none
+  // @internal
+  private _findFreeDimension(): number {
+    let dim = -1;
     for (let col = 0; col < this.width; col += 1) {
       const lowestZeroBit = ~this.bitmask[col] & -~this.bitmask[col];
       if (lowestZeroBit) {
@@ -125,12 +119,11 @@ class BitArray {
 
   // allocate and return the dimension ID (bit position)
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  allocDimension() {
+  allocDimension(): number {
     let dim = this._findFreeDimension();
 
     // if we did not find free dimension, expand the bitarray.
-    if (dim === undefined) {
+    if (dim === -1) {
       this.width += 1;
 
       const biggerBitArray = new Int32Array(this.width * this.length);
@@ -151,8 +144,7 @@ class BitArray {
   // free a dimension for later use.  MUST deselect the dimension, as other
   // code assume the column will be zero valued.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  freeDimension(dim: any) {
+  freeDimension(dim: number): void {
     // all selection tests assume unallocated dimensions are zero valued.
     this.deselectAll(dim);
     const col = dim >>> 5;
@@ -162,8 +154,7 @@ class BitArray {
 
   // return true if this index is selected in ALL dimensions.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  isSelected(index: any) {
+  isSelected(index: number): boolean {
     const { width, length, bitarray } = this;
 
     for (let w = 0; w < width; w += 1) {
@@ -175,8 +166,7 @@ class BitArray {
 
   // return true if this index is selected in ALL dimensions IGNORING dim
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  isSelectedIgnoringDim(index: any, dim: any) {
+  isSelectedIgnoringDim(index: number, dim: number): boolean {
     const ignoreOffset = dim >>> 5;
     const ignoreMask = ~(1 << dim % 32);
 
@@ -200,8 +190,7 @@ class BitArray {
 
   // select index on dimension
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectOne(dim: any, index: any) {
+  selectOne(dim: number, index: number): void {
     const col = dim >>> 5;
     const before = this.bitarray[col * this.length + index];
     const after = before | (1 << dim % 32);
@@ -210,8 +199,7 @@ class BitArray {
 
   // deselect index on dimension
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  deselectOne(dim: any, index: any) {
+  deselectOne(dim: number, index: number): void {
     const col = dim >>> 5;
     const before = this.bitarray[col * this.length + index];
     const after = before & ~(1 << dim % 32);
@@ -220,8 +208,7 @@ class BitArray {
 
   // select all indices on dimension.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectAll(dim: any) {
+  selectAll(dim: number): void {
     const col = dim >> 5;
     const one = 1 << dim % 32;
     for (let i = col * this.length, len = i + this.length; i < len; i += 1) {
@@ -231,8 +218,7 @@ class BitArray {
 
   // deselect all indices on dimension
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  deselectAll(dim: any) {
+  deselectAll(dim: number): void {
     const col = dim >> 5;
     const zero = ~(1 << dim % 32);
     for (let i = col * this.length, len = i + this.length; i < len; i += 1) {
@@ -242,8 +228,7 @@ class BitArray {
 
   // select range of indices on a dimension
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectFromRange(dim: any, range: any) {
+  selectFromRange(dim: number, range: Interval): void {
     const col = dim >>> 5;
     const first = range[0];
     const last = range[1];
@@ -257,8 +242,11 @@ class BitArray {
   // select range of indices on a dimension, indirect through a sort map.
   // Indirect functions are used to map between sort and natural order.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectIndirectFromRange(dim: any, indirect: any, range: any) {
+  selectIndirectFromRange(
+    dim: number,
+    indirect: Uint32Array,
+    range: Interval
+  ): void {
     const col = dim >>> 5;
     const first = range[0];
     const last = range[1];
@@ -271,8 +259,7 @@ class BitArray {
 
   // deselect range of indices on a dimension
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  deselectFromRange(dim: any, range: any) {
+  deselectFromRange(dim: number, range: Interval): void {
     const col = dim >>> 5;
     const first = range[0];
     const last = range[1];
@@ -285,8 +272,11 @@ class BitArray {
 
   // deselect range of indices on a dimension, indirect through a sort map.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  deselectIndirectFromRange(dim: any, indirect: any, range: any) {
+  deselectIndirectFromRange(
+    dim: number,
+    indirect: Uint32Array,
+    range: Interval
+  ): void {
     const col = dim >>> 5;
     const first = range[0];
     const last = range[1];
@@ -300,8 +290,11 @@ class BitArray {
   // Fill the array with selected|deselected value based upon the
   // current selection state.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  fillBySelection(result: any, selectedValue: any, deselectedValue: any) {
+  fillBySelection<A extends TypedArray>(
+    result: A,
+    selectedValue: A[0],
+    deselectedValue: A[0]
+  ): A {
     // special case (width === 1) for performance
     if (this.width === 1) {
       const { bitmask, bitarray } = this;

--- a/client/src/util/typedCrossfilter/crossfilter.ts
+++ b/client/src/util/typedCrossfilter/crossfilter.ts
@@ -504,7 +504,7 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
 
   // Two constructor modes - caller can provide a pre-created value array,
   // a map function which will create it, or another array which
-  // will copied into the user-specified value array.
+  // will be copied into the user-specified value array.
 
   constructor(name: string, length: number, params: ScalarDimensionParameters) {
     super(name);
@@ -655,7 +655,7 @@ class ImmutableSpatialDimension extends _ImmutableBaseDimension {
     super(name);
 
     const { X, Y } = params;
-    if (X.length !== Y.length && X.length !== length) {
+    if (X.length !== Y.length || X.length !== length) {
       throw new RangeError(
         "SpatialDimension values must have same dimensionality as crossfilter"
       );

--- a/client/src/util/typedCrossfilter/crossfilter.ts
+++ b/client/src/util/typedCrossfilter/crossfilter.ts
@@ -78,11 +78,11 @@ export function isCrossfilterData(tbd: unknown): tbd is CrossfilterData {
 export default class ImmutableTypedCrossfilter<
   RecordType extends CrossfilterData = CrossfilterData
 > {
-  data: RecordType;
+  public data: RecordType;
 
-  dimensions: Dimensions;
+  private dimensions: Dimensions;
 
-  selectionCache: PartialSelectionCache;
+  private selectionCache: PartialSelectionCache;
 
   constructor(
     data: RecordType,
@@ -146,13 +146,6 @@ export default class ImmutableTypedCrossfilter<
   hasDimension(name: string): boolean {
     return !!this.dimensions[name];
   }
-
-  /* Helpers */
-  DimTypes = {
-    scalar: ImmutableScalarDimension,
-    enum: ImmutableEnumDimension,
-    spatial: ImmutableSpatialDimension,
-  };
 
   addDimension(
     name: string,
@@ -347,7 +340,7 @@ export default class ImmutableTypedCrossfilter<
     return { bitArray };
   }
 
-  _getSelectionCache(): SelectionCache {
+  private _getSelectionCache(): SelectionCache {
     if (!this.selectionCache) this.selectionCache = {};
 
     if (!this.selectionCache.bitArray) {
@@ -372,12 +365,14 @@ export default class ImmutableTypedCrossfilter<
     return this.selectionCache as SelectionCache;
   }
 
-  _clearSelectionCache(): PartialSelectionCache {
+  private _clearSelectionCache(): PartialSelectionCache {
     this.selectionCache = {};
     return this.selectionCache;
   }
 
-  _setSelectionCache(vals: PartialSelectionCache = {}): PartialSelectionCache {
+  private _setSelectionCache(
+    vals: PartialSelectionCache = {}
+  ): PartialSelectionCache {
     Object.assign(this.selectionCache, vals);
     return this.selectionCache;
   }
@@ -503,9 +498,9 @@ class _ImmutableBaseDimension {
 }
 
 class ImmutableScalarDimension extends _ImmutableBaseDimension {
-  index: IndexArray;
+  protected index: IndexArray;
 
-  value: SortableArray;
+  protected value: SortableArray;
 
   // Two constructor modes - caller can provide a pre-created value array,
   // a map function which will create it, or another array which
@@ -601,7 +596,7 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
 }
 
 class ImmutableEnumDimension extends ImmutableScalarDimension {
-  enumIndex: SortableArray;
+  private enumIndex: SortableArray;
 
   constructor(name: string, length: number, params: EnumDimensionParameters) {
     const { value } = params;
@@ -644,13 +639,13 @@ class ImmutableEnumDimension extends ImmutableScalarDimension {
 }
 
 class ImmutableSpatialDimension extends _ImmutableBaseDimension {
-  X: TypedArray;
+  private X: TypedArray;
 
-  Xindex: IndexArray;
+  private Xindex: IndexArray;
 
-  Y: TypedArray;
+  private Y: TypedArray;
 
-  Yindex: IndexArray;
+  private Yindex: IndexArray;
 
   constructor(
     name: string,

--- a/client/src/util/typedCrossfilter/crossfilter.ts
+++ b/client/src/util/typedCrossfilter/crossfilter.ts
@@ -1,5 +1,28 @@
 // eslint-disable-next-line max-classes-per-file -- classes are interrelated
-import PositiveIntervals from "./positiveIntervals";
+import {
+  AnyArray,
+  isAnyArray,
+  TypedArray,
+  SortableArray,
+} from "../../common/types/arraytypes";
+import {
+  IndexArray,
+  SelectionMode,
+  CrossfilterSelector,
+  SelectExact,
+  SelectRange,
+  SelectWithinRect,
+  SelectWithinPolygon,
+  ScalarDimensionParameters,
+  EnumDimensionParameters,
+  SpatialDimensionParameters,
+  CrossfilterDimensionParameters,
+} from "./types";
+import { Dataframe } from "../dataframe";
+import PositiveIntervals, {
+  Interval,
+  IntervalArray,
+} from "./positiveIntervals";
 import BitArray from "./bitArray";
 import {
   sortArray,
@@ -8,32 +31,64 @@ import {
   lowerBoundIndirect,
   upperBoundIndirect,
 } from "./sort";
-import { makeSortIndex } from "./util";
-import { isAnyArray } from "../../common/types/arraytypes";
+import { makeSortIndex, NotImplementedError } from "./util";
 
-class NotImplementedError extends Error {
-  constructor(msg: string) {
-    super(msg);
+/**
+ * The result of a dimension selection
+ * @internal
+ */
+type DimensionSelectionResult = {
+  ranges: IntervalArray;
+  index: IndexArray | null;
+};
 
-    // Maintains proper stack trace for where our error was thrown (only available on V8)
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, NotImplementedError);
-    }
-  }
+/**
+ * Table of dimensions added to the crossfilter
+ * @internal
+ */
+interface Dimension {
+  id: number | undefined; // ID is often undefined when selection cache is clear
+  dim: _ImmutableBaseDimension;
+  name: string;
+  selection: DimensionSelectionResult;
+}
+interface Dimensions {
+  [name: string]: Dimension;
 }
 
-export default class ImmutableTypedCrossfilter {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  data: any;
+/**
+ * Selection performance cache
+ * @internal
+ */
+interface SelectionCache {
+  bitArray: BitArray;
+  allSelectedMask?: Uint8Array;
+  countSelected?: number;
+}
+type PartialSelectionCache = Partial<SelectionCache>;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  dimensions: any;
+/**
+ * The type of our "data" (aka records)
+ */
+export type CrossfilterData = AnyArray | Dataframe;
+export function isCrossfilterData(tbd: unknown): tbd is CrossfilterData {
+  return isAnyArray(tbd) || tbd instanceof Dataframe;
+}
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  selectionCache: any;
+export default class ImmutableTypedCrossfilter<
+  RecordType extends CrossfilterData = CrossfilterData
+> {
+  data: RecordType;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  constructor(data: any, dimensions = {}, selectionCache = {}) {
+  dimensions: Dimensions;
+
+  selectionCache: PartialSelectionCache;
+
+  constructor(
+    data: RecordType,
+    dimensions: Dimensions = {},
+    selectionCache: PartialSelectionCache = {}
+  ) {
     /*
     Typically, parameter 'data' is one of:
       - Array of objects/records
@@ -45,8 +100,8 @@ export default class ImmutableTypedCrossfilter {
     - selectionCache: object which may contains a bit array indicating
       the flatted selection state for all dimensions, plus other state
       summarizing the selection.  This is lazily created and is effectively
-      a perfomance cache.  Methods which return a new crossfilter,
-      such as select(), addDimention() and delDimension(), will pass
+      a performance cache.  Methods which return a new crossfilter,
+      such as select(), addDimension() and delDimension(), will pass
       the cache forward to the new object, as the typical "immutable API"
       usage pattern is to retain the new crossfilter and discard the old.
       If the cache object is empty, it will be rebuilt.
@@ -56,6 +111,8 @@ export default class ImmutableTypedCrossfilter {
         - name: the dimension name
         - selection: the dimension's current selection
     */
+    if (!isCrossfilterData(data))
+      throw new TypeError("Unsupported crossfilter data type.");
     this.data = data;
     this.selectionCache = selectionCache; /* { BitArray, ... }*/
     this.dimensions = dimensions; /* name: { id, dim, name, selection } */
@@ -66,32 +123,41 @@ export default class ImmutableTypedCrossfilter {
     return this.data.length;
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  all() {
+  all(): RecordType {
     return this.data;
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  setData(data: any) {
+  setData(data: RecordType): ImmutableTypedCrossfilter<RecordType> {
     if (this.data === data) return this;
+
+    if (!isCrossfilterData(data))
+      throw new TypeError("Unsupported crossfilter data type.");
+
     // please leave, WIP
     // console.log("...crossfilter set data, will drop cache");
-    return new ImmutableTypedCrossfilter(data, this.dimensions);
+    return new ImmutableTypedCrossfilter<RecordType>(data, this.dimensions);
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  dimensionNames() {
+  dimensionNames(): string[] {
     /* return array of all dimensions (by name) */
     return Object.keys(this.dimensions);
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  hasDimension(name: any) {
+  hasDimension(name: string): boolean {
     return !!this.dimensions[name];
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  addDimension(name: any, type: any, ...rest: any[]) {
+  /* Helpers */
+  DimTypes = {
+    scalar: ImmutableScalarDimension,
+    enum: ImmutableEnumDimension,
+    spatial: ImmutableSpatialDimension,
+  };
+
+  addDimension(
+    name: string,
+    params: CrossfilterDimensionParameters
+  ): ImmutableTypedCrossfilter<RecordType> {
     /*
     Add a new dimension to this crossfilter, of type DimensionType.
     Remainder of parameters are dimension-type-specific.
@@ -105,32 +171,44 @@ export default class ImmutableTypedCrossfilter {
 
     this._clearSelectionCache();
 
-    let id;
+    let id: number | undefined;
     if (bitArray) {
       id = bitArray.allocDimension();
       bitArray.selectAll(id);
     }
-    // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    const DimensionType = DimTypes[type];
-    const dim = new DimensionType(name, data, ...rest);
+
+    let dim: _ImmutableBaseDimension;
+    switch (params.type) {
+      case "scalar":
+        dim = new ImmutableScalarDimension(name, this.data.length, params);
+        break;
+      case "enum":
+        dim = new ImmutableEnumDimension(name, this.data.length, params);
+        break;
+      case "spatial":
+        dim = new ImmutableSpatialDimension(name, this.data.length, params);
+        break;
+      default:
+        throw new TypeError("Unknown dimension type.");
+    }
+
     Object.freeze(dim);
-    const dimensions = {
+    const dimensions: Dimensions = {
       ...this.dimensions,
       [name]: {
         id,
         dim,
         name,
-        selection: dim.select({ mode: "all" }),
+        selection: dim.select({ mode: SelectionMode.All }),
       },
     };
 
-    return new ImmutableTypedCrossfilter(data, dimensions, {
+    return new ImmutableTypedCrossfilter<RecordType>(data, dimensions, {
       bitArray,
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  delDimension(name: any) {
+  delDimension(name: string): ImmutableTypedCrossfilter<RecordType> {
     const { data } = this;
     const { bitArray } = this.selectionCache;
     const dimensions = { ...this.dimensions };
@@ -142,16 +220,20 @@ export default class ImmutableTypedCrossfilter {
     delete dimensions[name];
     this._clearSelectionCache();
     if (bitArray) {
+      if (id === undefined)
+        throw new Error("Internal selection cache inconsistent.");
       bitArray.freeDimension(id);
     }
 
-    return new ImmutableTypedCrossfilter(data, dimensions, {
+    return new ImmutableTypedCrossfilter<RecordType>(data, dimensions, {
       bitArray,
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  renameDimension(oldName: any, newName: any) {
+  renameDimension(
+    oldName: string,
+    newName: string
+  ): ImmutableTypedCrossfilter<RecordType> {
     const { [oldName]: dim, ...dimensions } = this.dimensions;
     const { data, selectionCache } = this;
     const newDimensions = {
@@ -162,11 +244,17 @@ export default class ImmutableTypedCrossfilter {
         dim: dim.dim.rename(newName),
       },
     };
-    return new ImmutableTypedCrossfilter(data, newDimensions, selectionCache);
+    return new ImmutableTypedCrossfilter<RecordType>(
+      data,
+      newDimensions,
+      selectionCache
+    );
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  select(name: any, spec: any) {
+  select(
+    name: string,
+    spec: CrossfilterSelector
+  ): ImmutableTypedCrossfilter<RecordType> {
     /*
     select on named dimension, as indicated by `spec`.   Spec is an object
     specifying the selection, and must contain at least a `mode` field.
@@ -191,20 +279,19 @@ export default class ImmutableTypedCrossfilter {
       newSelection,
       oldSelection
     );
-    return new ImmutableTypedCrossfilter(data, dimensions, newSelectionCache);
+    return new ImmutableTypedCrossfilter<RecordType>(
+      data,
+      dimensions,
+      newSelectionCache
+    );
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  static _dimSelnHasUpdated(
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    selectionCache: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    id: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    newSeln: any,
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-    oldSeln: any
-  ) {
+  private static _dimSelnHasUpdated(
+    selectionCache: PartialSelectionCache,
+    id: number | undefined,
+    newSeln: DimensionSelectionResult,
+    oldSeln: DimensionSelectionResult
+  ): PartialSelectionCache {
     /*
     Selection has updated from oldSeln to newSeln.   Update the
     bit array if it exists.  If not, we will lazy create it when
@@ -213,14 +300,16 @@ export default class ImmutableTypedCrossfilter {
     if (!selectionCache || !selectionCache.bitArray) return {};
 
     const { bitArray } = selectionCache;
+    if (id === undefined)
+      throw new Error("Internal selection cache inconsistent.");
 
     /*
       if both new and old selection use the same index, we can
       perform an incremental update. If the index changed, we have
       to do a suboptimal full deselect/select.
       */
-    let adds;
-    let dels;
+    let adds: IntervalArray;
+    let dels: IntervalArray;
     if (newSeln.index === oldSeln.index) {
       adds = PositiveIntervals.difference(newSeln.ranges, oldSeln.ranges);
       dels = PositiveIntervals.difference(oldSeln.ranges, newSeln.ranges);
@@ -237,31 +326,28 @@ export default class ImmutableTypedCrossfilter {
 
       If sort index exists in the dimension, assume sort ordered ranges.
       */
-    if (oldSeln.index) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-      dels.forEach((interval: any) =>
-        bitArray.deselectIndirectFromRange(id, oldSeln.index, interval)
+    const oldIndex = oldSeln.index;
+    if (oldIndex) {
+      dels.forEach((interval) =>
+        bitArray.deselectIndirectFromRange(id, oldIndex, interval)
       );
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-      dels.forEach((interval: any) => bitArray.deselectFromRange(id, interval));
+      dels.forEach((interval) => bitArray.deselectFromRange(id, interval));
     }
 
-    if (newSeln.index) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-      adds.forEach((interval: any) =>
-        bitArray.selectIndirectFromRange(id, newSeln.index, interval)
+    const newIndex = newSeln.index;
+    if (newIndex) {
+      adds.forEach((interval) =>
+        bitArray.selectIndirectFromRange(id, newIndex, interval)
       );
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-      adds.forEach((interval: any) => bitArray.selectFromRange(id, interval));
+      adds.forEach((interval) => bitArray.selectFromRange(id, interval));
     }
 
     return { bitArray };
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  _getSelectionCache() {
+  _getSelectionCache(): SelectionCache {
     if (!this.selectionCache) this.selectionCache = {};
 
     if (!this.selectionCache.bitArray) {
@@ -272,8 +358,7 @@ export default class ImmutableTypedCrossfilter {
         const id = bitArray.allocDimension();
         this.dimensions[name].id = id;
         const { ranges, index } = selection;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-        ranges.forEach((range: any) => {
+        ranges.forEach((range) => {
           if (index) {
             bitArray.selectIndirectFromRange(id, index, range);
           } else {
@@ -283,23 +368,21 @@ export default class ImmutableTypedCrossfilter {
       });
       this.selectionCache.bitArray = bitArray;
     }
-    return this.selectionCache;
+    // Guaranteed bitarray is now set.
+    return this.selectionCache as SelectionCache;
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  _clearSelectionCache() {
+  _clearSelectionCache(): PartialSelectionCache {
     this.selectionCache = {};
     return this.selectionCache;
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  _setSelectionCache(vals = {}) {
+  _setSelectionCache(vals: PartialSelectionCache = {}): PartialSelectionCache {
     Object.assign(this.selectionCache, vals);
     return this.selectionCache;
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  allSelected() {
+  allSelected(): CrossfilterData {
     /*
     return array of all records currently selected by all dimensions
     */
@@ -307,20 +390,23 @@ export default class ImmutableTypedCrossfilter {
     const { bitArray } = selectionCache;
     const { data } = this;
     if (Array.isArray(data)) {
-      const res = [];
+      const res: unknown[] = [];
       for (let i = 0, len = data.length; i < len; i += 1) {
         if (bitArray.isSelected(i)) {
           res.push(data[i]);
         }
       }
-      return res;
+      return res as SortableArray;
     }
-    /* else, Dataframe-like */
-    return data.isubsetMask(this.allSelectedMask());
+    if (data instanceof Dataframe) {
+      /* else, Dataframe-like */
+      return data.isubsetMask(this.allSelectedMask(), null);
+    }
+    /* or error! */
+    throw new TypeError("Unsupported data type!");
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  allSelectedMask() {
+  allSelectedMask(): Uint8Array {
     /*
     return Uint8Array containing selection state (truthy/falsey) for each record.
     */
@@ -338,8 +424,7 @@ export default class ImmutableTypedCrossfilter {
     return allSelectedMask;
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-  countSelected() {
+  countSelected(): number {
     /*
     return number of records selected on all dimensions
     */
@@ -353,8 +438,7 @@ export default class ImmutableTypedCrossfilter {
     return countSelected;
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  isElementSelected(i: any) {
+  isElementSelected(i: number): boolean {
     /*
     return truthy/falsey if this record is selected on all dimensions
     */
@@ -362,8 +446,11 @@ export default class ImmutableTypedCrossfilter {
     return selectionCache.bitArray.isSelected(i);
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  fillByIsSelected(array: any, selectedValue: any, deselectedValue: any) {
+  fillByIsSelected<A extends TypedArray>(
+    array: A,
+    selectedValue: A[0],
+    deselectedValue: A[0]
+  ): A {
     /*
     fill array with one of two values, based upon selection state.
     */
@@ -388,11 +475,9 @@ for a dimension:
   - name - the dimension name/label.
 */
 class _ImmutableBaseDimension {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  name: any;
+  name: string;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  constructor(name: any) {
+  constructor(name: string) {
     this.name = name;
   }
 
@@ -400,15 +485,13 @@ class _ImmutableBaseDimension {
     return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  rename(name: any) {
+  rename(name: string) {
     const d = this.clone();
     d.name = name;
     return d;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  select(spec: any) {
+  select(spec: CrossfilterSelector): DimensionSelectionResult {
     const { mode } = spec;
     if (mode === undefined) {
       throw new Error("select spec does not contain 'mode'");
@@ -420,94 +503,75 @@ class _ImmutableBaseDimension {
 }
 
 class ImmutableScalarDimension extends _ImmutableBaseDimension {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  index: any;
+  index: IndexArray;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  value: any;
+  value: SortableArray;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  constructor(name: any, data: any, value: any, ValueArrayType: any) {
+  // Two constructor modes - caller can provide a pre-created value array,
+  // a map function which will create it, or another array which
+  // will copied into the user-specified value array.
+
+  constructor(name: string, length: number, params: ScalarDimensionParameters) {
     super(name);
 
-    // Three modes - caller can provide a pre-created value array,
-    // a map function which will create it, or another array which
-    // will used with an identity map function.
+    const { value, ValueArrayCtor } = params;
+
     let array;
-    if (value instanceof ValueArrayType) {
-      // user has provided the final typed array - just use it
-      if (value.length !== data.length) {
-        throw new RangeError(
-          "ScalarDimension values length must equal crossfilter data record count"
-        );
+    if (ValueArrayCtor !== undefined) {
+      if (value instanceof ValueArrayCtor) {
+        // user has provided the final typed array - just use it
+        if (value.length !== length) {
+          throw new RangeError(
+            "ScalarDimension values length must equal crossfilter data record count"
+          );
+        }
+        array = value;
+      } else if (isAnyArray(value)) {
+        // Create value array from user-provided array ctor. Typically used
+        // only by enumerated dimensions.  May be overridden in subclass.
+        array = new ValueArrayCtor(length);
+        for (let i = 0; i < length; i += 1) {
+          array[i] = value[i];
+        }
       }
-      array = value;
-    } else if (value instanceof Function) {
-      // Create value array from user-provided map function.
-      array = this._createValueArray(
-        data,
-        value,
-        new ValueArrayType(data.length)
-      );
-    } else if (isAnyArray(value)) {
-      // Create value array from user-provided array.  Typically used
-      // only by enumerated dimensions
-      array = this._createValueArray(
-        data,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-        (i: any) => value[i],
-        new ValueArrayType(data.length)
-      );
-    } else {
+    }
+    if (!array) {
       throw new NotImplementedError(
         "dimension value must be function or value array type"
       );
     }
+
     this.value = array;
 
     // create sort index
     this.index = makeSortIndex(array);
   }
 
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- needed for polymorphism
-  _createValueArray(data: any, mapf: any, array: any) {
-    // create dimension value array
-    const len = data.length;
-    const larray = array;
-    for (let i = 0; i < len; i += 1) {
-      larray[i] = mapf(i, data);
-    }
-    return larray;
-  }
-
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  select(spec: any) {
-    const { mode } = spec;
+  select(spec: CrossfilterSelector): DimensionSelectionResult {
     const { index } = this;
-    switch (mode) {
-      case "all":
+    switch (spec.mode) {
+      case SelectionMode.All:
         return { ranges: [[0, this.value.length]], index };
-      case "none":
+      case SelectionMode.None:
         return { ranges: [], index };
-      case "exact":
+      case SelectionMode.Exact:
         return this.selectExact(spec);
-      case "range":
+      case SelectionMode.Range:
         return this.selectRange(spec);
       default:
         return super.select(spec);
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectExact(spec: any) {
+  selectExact(spec: SelectExact): DimensionSelectionResult {
     const { value, index } = this;
     let { values } = spec;
     if (!Array.isArray(values)) {
       values = [values];
     }
-    const ranges = [];
+    const ranges: IntervalArray = [];
     for (let v = 0, len = values.length; v < len; v += 1) {
-      const r = [
+      const r: Interval = [
         lowerBoundIndirect(value, index, values[v], 0, value.length),
         upperBoundIndirect(value, index, values[v], 0, value.length),
       ];
@@ -518,15 +582,14 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
     return { ranges, index };
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectRange(spec: any) {
+  selectRange(spec: SelectRange): DimensionSelectionResult {
     const { value, index } = this;
     /* 
     if !inclusive: [lo, hi) else [lo, hi]
     */
     const { lo, hi, inclusive } = spec;
-    const ranges = [];
-    const r = [
+    const ranges: IntervalArray = [];
+    const r: Interval = [
       lowerBoundIndirect(value, index, lo, 0, value.length),
       inclusive
         ? upperBoundIndirect(value, index, hi, 0, value.length)
@@ -538,39 +601,28 @@ class ImmutableScalarDimension extends _ImmutableBaseDimension {
 }
 
 class ImmutableEnumDimension extends ImmutableScalarDimension {
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  constructor(name: any, data: any, value: any) {
-    super(name, data, value, Uint32Array);
-  }
+  enumIndex: SortableArray;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  _createValueArray(data: any, mapf: any, array: any) {
-    const len = data.length;
-    const larray = array;
-
-    // create enumeration table - mapping between the value
-    // and the enum.
-    const s = new Set();
-    for (let i = 0; i < len; i += 1) {
-      s.add(mapf(i, data));
-    }
+  constructor(name: string, length: number, params: EnumDimensionParameters) {
+    const { value } = params;
+    const s = new Set(value);
     const enumIndex = sortArray(Array.from(s));
-    // @ts-expect-error FIXME Adding enumIndex as member variable results in "undefined" enumIndex value
-    this.enumIndex = enumIndex;
-
-    // create dimension value array
-    const enumLen = enumIndex.length;
-    for (let i = 0; i < len; i += 1) {
-      const v = mapf(i, data);
-      const e = lowerBound(enumIndex, v, 0, enumLen);
-      larray[i] = e;
+    const indexArr = new Uint32Array(length);
+    for (let i = 0; i < length; i += 1) {
+      const v = value[i];
+      const e = lowerBound(enumIndex, v, 0, enumIndex.length);
+      indexArr[i] = e;
     }
-    return larray;
+
+    super(name, length, {
+      type: "scalar",
+      value: indexArr,
+      ValueArrayCtor: Uint32Array,
+    });
+    this.enumIndex = enumIndex;
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectExact(spec: any) {
-    // @ts-expect-error FIXME Adding enumIndex as member variable results in "undefined" enumIndex value
+  selectExact(spec: SelectExact): DimensionSelectionResult {
     const { enumIndex } = this;
     let { values } = spec;
     if (!Array.isArray(values)) {
@@ -578,38 +630,37 @@ class ImmutableEnumDimension extends ImmutableScalarDimension {
     }
     return super.selectExact({
       mode: spec.mode,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-      values: values.map((v: any) =>
+      values: values.map((v) =>
         binarySearch(enumIndex, v, 0, enumIndex.length)
       ),
     });
   }
 
-  // @ts-expect-error ts-migrate(2416) FIXME: Property 'selectRange' in type 'ImmutableEnumDimen... Remove this comment to see the full error message
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/explicit-module-boundary-types -- enables polymorphism
-  selectRange() {
-    throw new Error("range selection unsupported on Enumerated dimension");
+  selectRange(spec: SelectRange): DimensionSelectionResult {
+    throw new Error(
+      `select mode ${spec.mode} not implemented by dimension ${this.name}`
+    );
   }
 }
 
 class ImmutableSpatialDimension extends _ImmutableBaseDimension {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  X: any;
+  X: TypedArray;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  Xindex: any;
+  Xindex: IndexArray;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  Y: any;
+  Y: TypedArray;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  Yindex: any;
+  Yindex: IndexArray;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  constructor(name: any, data: any, X: any, Y: any) {
+  constructor(
+    name: string,
+    length: number,
+    params: SpatialDimensionParameters
+  ) {
     super(name);
 
-    if (X.length !== Y.length && X.length !== data.length) {
+    const { X, Y } = params;
+    if (X.length !== Y.length && X.length !== length) {
       throw new RangeError(
         "SpatialDimension values must have same dimensionality as crossfilter"
       );
@@ -621,31 +672,28 @@ class ImmutableSpatialDimension extends _ImmutableBaseDimension {
     this.Yindex = makeSortIndex(Y);
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  select(spec: any) {
-    const { mode } = spec;
-    switch (mode) {
-      case "all":
+  select(spec: CrossfilterSelector): DimensionSelectionResult {
+    switch (spec.mode) {
+      case SelectionMode.All:
         return { ranges: [[0, this.X.length]], index: null };
-      case "none":
+      case SelectionMode.None:
         return { ranges: [], index: null };
-      case "within-rect":
+      case SelectionMode.WithinRect:
         return this.selectWithinRect(spec);
-      case "within-polygon":
+      case SelectionMode.WithinPolygon:
         return this.selectWithinPolygon(spec);
       default:
         return super.select(spec);
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectWithinRect(spec: any) {
+  selectWithinRect(spec: SelectWithinRect): DimensionSelectionResult {
     /*
       { mode: "within-rect", minX: 1, minY: 0, maxX: 3, maxY: 9 }
     */
     const { minX, minY, maxX, maxY } = spec;
     const { X, Y } = this;
-    const ranges = [];
+    const ranges: IntervalArray = [];
     let start = -1;
     for (let i = 0, l = X.length; i < l; i += 1) {
       const x = X[i];
@@ -672,8 +720,7 @@ class ImmutableSpatialDimension extends _ImmutableBaseDimension {
     * then the polygon test is applied
   */
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  selectWithinPolygon(spec: any) {
+  selectWithinPolygon(spec: SelectWithinPolygon): DimensionSelectionResult {
     /*
       { mode: "within-polygon", polygon: [ [x0, y0], ... ] }
     */
@@ -697,7 +744,7 @@ class ImmutableSpatialDimension extends _ImmutableBaseDimension {
       index = Yindex;
     }
 
-    const ranges = [];
+    const ranges: IntervalArray = [];
     let start = -1;
     for (let i = slice[0], e = slice[1]; i < e; i += 1) {
       const rid = index[i];
@@ -721,16 +768,8 @@ class ImmutableSpatialDimension extends _ImmutableBaseDimension {
   }
 }
 
-/* Helpers */
-export const DimTypes = {
-  scalar: ImmutableScalarDimension,
-  enum: ImmutableEnumDimension,
-  spatial: ImmutableSpatialDimension,
-};
-
 /* return bounding box of the polygon */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function polygonBoundingBox(polygon: any) {
+function polygonBoundingBox(polygon: [number, number][]) {
   let minX = Number.MAX_VALUE;
   let minY = Number.MAX_VALUE;
   let maxX = Number.MIN_VALUE;
@@ -754,8 +793,7 @@ function polygonBoundingBox(polygon: any) {
  *  @param {float} y - point y coordinate
  *  @type {boolean}
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function withinPolygon(polygon: any, x: any, y: any) {
+function withinPolygon(polygon: [number, number][], x: number, y: number) {
   const n = polygon.length;
   let p = polygon[n - 1];
   let x0 = p[0];

--- a/client/src/util/typedCrossfilter/index.ts
+++ b/client/src/util/typedCrossfilter/index.ts
@@ -31,4 +31,8 @@ more complex API.  In a few cases, elements of that API were incorporated.
 See test cases for some concrete examples.
 */
 
+export type {
+  CrossfilterSelector,
+  CrossfilterDimensionParameters,
+} from "./types";
 export { default } from "./crossfilter";

--- a/client/src/util/typedCrossfilter/positiveIntervals.ts
+++ b/client/src/util/typedCrossfilter/positiveIntervals.ts
@@ -11,17 +11,19 @@
 // Code assumes intervals have a low cardinality; many operations are done
 // with a brute force scan.   Little attempt to reduce GC pressure.
 //
+
+export type Interval = [number, number];
+export type IntervalArray = Interval[];
+
 class PositiveIntervals {
   // Canonicalize - ensure that:
   //  1. no overlapping intervals
   //  2. sorted in order of interval min.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  static canonicalize(A: any) {
+  static canonicalize(A: IntervalArray): IntervalArray {
     if (A.length <= 1) return A;
     const copy = A.slice();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-    copy.sort((a: any, b: any) => a[0] - b[0]);
+    copy.sort((a, b) => a[0] - b[0]);
     const res = [];
     res.push(copy[0]);
     for (let i = 1, len = copy.length; i < len; i += 1) {
@@ -30,7 +32,6 @@ class PositiveIntervals {
         res.push(copy[i]);
       } else if (copy[i][1] > res[res.length - 1][1]) {
         // merge this into previous
-        // eslint-disable-line prefer-destructuring -- destructuring impedes readability
         res[res.length - 1][1] = copy[i][1];
       }
     }
@@ -40,14 +41,15 @@ class PositiveIntervals {
   // Return interval with values belonging to both A and B. Essentially
   // a set union operation.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  static union(A: any, B: any) {
+  static union(A: IntervalArray, B: IntervalArray): IntervalArray {
     return PositiveIntervals.canonicalize([...A, ...B]);
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  static _flatten(A: any, B: any) {
-    const points = []; /* point, A, start */
+  static _flatten(
+    A: IntervalArray,
+    B: IntervalArray
+  ): [number, boolean, boolean][] {
+    const points: [number, boolean, boolean][] = []; /* point, A, start */
     for (let a = 0; a < A.length; a += 1) {
       points.push([A[a][0], true, true]);
       points.push([A[a][1], true, false]);
@@ -64,8 +66,7 @@ class PositiveIntervals {
   // A - B, ie, the interval with all values in A that are not in B.  Essentially
   // a set difference operation.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  static difference(A: any, B: any) {
+  static difference(A: IntervalArray, B: IntervalArray): IntervalArray {
     // Corner cases
     if (A.length === 0 || B.length === 0) {
       return PositiveIntervals.canonicalize(A);
@@ -75,7 +76,7 @@ class PositiveIntervals {
     const cB = PositiveIntervals.canonicalize(B);
 
     const points = PositiveIntervals._flatten(cA, cB);
-    const res = [];
+    const res: IntervalArray = [];
     let aDepth = 0;
     let depth = 0;
     let intervalStart;
@@ -101,8 +102,7 @@ class PositiveIntervals {
   // Return interval with values belonging to A or B.  Essentially a set
   // intersection.
   //
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  static intersection(A: any, B: any) {
+  static intersection(A: IntervalArray, B: IntervalArray): IntervalArray {
     if (A.length === 0 || B.length === 0) {
       return [];
     }
@@ -111,7 +111,7 @@ class PositiveIntervals {
     const cB = PositiveIntervals.canonicalize(B);
 
     const points = PositiveIntervals._flatten(cA, cB);
-    const res = [];
+    const res: IntervalArray = [];
     let depth = 0;
     let intervalStart;
     for (let i = 0; i < points.length; i += 1) {

--- a/client/src/util/typedCrossfilter/sort.ts
+++ b/client/src/util/typedCrossfilter/sort.ts
@@ -1,4 +1,11 @@
-import { isTypedArray, isFloatTypedArray } from "../../common/types/arraytypes";
+import {
+  isTypedArray,
+  isFloatTypedArray,
+  FloatTypedArray,
+  SortableArray,
+} from "../../common/types/arraytypes";
+
+import { NonFloatSortableArray, IndexArray } from "./types";
 
 /* eslint-disable no-bitwise -- code relies on bitwise ops */
 
@@ -10,14 +17,12 @@ import { isTypedArray, isFloatTypedArray } from "../../common/types/arraytypes";
 /*
 Comparators for float sort.   -Infinity < finite < Infinity < NaN
 */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function lt(a: any, b: any) {
+function lt(a: number, b: number) {
   if (Number.isNaN(b)) return !Number.isNaN(a);
   return a < b;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function gt(a: any, b: any) {
+function gt(a: number, b: number) {
   if (Number.isNaN(a)) return !Number.isNaN(b);
   return a > b;
 }
@@ -26,8 +31,11 @@ function gt(a: any, b: any) {
 insertion sort, used for small arrays (controlled by SMALL_ARRAY constant)
 */
 const SMALL_ARRAY = 32;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function insertionsort(a: any, lo: any, hi: any) {
+function insertionsort<T extends NonFloatSortableArray>(
+  a: T,
+  lo: number,
+  hi: number
+): T {
   for (let i = lo + 1; i < hi + 1; i += 1) {
     const x = a[i];
     let j;
@@ -39,8 +47,11 @@ function insertionsort(a: any, lo: any, hi: any) {
   return a;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function insertionsortFloats(a: any, lo: any, hi: any) {
+function insertionsortFloats<T extends FloatTypedArray>(
+  a: T,
+  lo: number,
+  hi: number
+): T {
   for (let i = lo + 1; i < hi + 1; i += 1) {
     const x = a[i];
     let j;
@@ -52,8 +63,12 @@ function insertionsortFloats(a: any, lo: any, hi: any) {
   return a;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function insertionsortIndirect(a: any, s: any, lo: any, hi: any) {
+function insertionsortIndirect(
+  a: IndexArray,
+  s: NonFloatSortableArray,
+  lo: number,
+  hi: number
+): IndexArray {
   for (let i = lo + 1; i < hi + 1; i += 1) {
     const x = a[i];
     const t = s[x];
@@ -66,8 +81,12 @@ function insertionsortIndirect(a: any, s: any, lo: any, hi: any) {
   return a;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function insertionsortFloatsIndirect(a: any, s: any, lo: any, hi: any) {
+function insertionsortFloatsIndirect(
+  a: IndexArray,
+  s: FloatTypedArray,
+  lo: number,
+  hi: number
+): IndexArray {
   for (let i = lo + 1; i < hi + 1; i += 1) {
     const x = a[i];
     const t = s[x];
@@ -83,8 +102,11 @@ function insertionsortFloatsIndirect(a: any, s: any, lo: any, hi: any) {
 /*
 Quicksort - used for larger arrays
 */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function quicksort(a: any, lo: any, hi: any) {
+function quicksort<T extends NonFloatSortableArray>(
+  a: T,
+  lo: number,
+  hi: number
+): T {
   if (hi - lo < SMALL_ARRAY) {
     return insertionsort(a, lo, hi);
   }
@@ -114,8 +136,11 @@ function quicksort(a: any, lo: any, hi: any) {
   return a;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function quicksortFloats(a: any, lo: any, hi: any) {
+function quicksortFloats<T extends FloatTypedArray>(
+  a: T,
+  lo: number,
+  hi: number
+): T {
   if (hi - lo < SMALL_ARRAY) {
     return insertionsortFloats(a, lo, hi);
   }
@@ -145,8 +170,12 @@ function quicksortFloats(a: any, lo: any, hi: any) {
   return a;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function quicksortIndirect(a: any, s: any, lo: any, hi: any) {
+function quicksortIndirect(
+  a: IndexArray,
+  s: NonFloatSortableArray,
+  lo: number,
+  hi: number
+): IndexArray {
   if (hi - lo < SMALL_ARRAY) {
     return insertionsortIndirect(a, s, lo, hi);
   }
@@ -177,8 +206,12 @@ function quicksortIndirect(a: any, s: any, lo: any, hi: any) {
   return a;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function quicksortFloatsIndirect(a: any, s: any, lo: any, hi: any) {
+function quicksortFloatsIndirect(
+  a: IndexArray,
+  s: FloatTypedArray,
+  lo: number,
+  hi: number
+): IndexArray {
   if (hi - lo < SMALL_ARRAY) {
     return insertionsortFloatsIndirect(a, s, lo, hi);
   }
@@ -213,8 +246,7 @@ function quicksortFloatsIndirect(a: any, s: any, lo: any, hi: any) {
 Convenience wrappers, handling optimization paths and default
 handlers for NaN comparisons.  Sorts in place.
 */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function sortArray(arr: any) {
+export function sortArray<T extends SortableArray>(arr: T): T {
   if (Array.isArray(arr)) {
     return quicksort(arr, 0, arr.length - 1);
   }
@@ -228,8 +260,10 @@ export function sortArray(arr: any) {
   throw new Error("sortArray received unsupported object type");
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function sortIndex(index: any, source: any) {
+export function sortIndex(
+  index: IndexArray,
+  source: SortableArray
+): IndexArray {
   if (isFloatTypedArray(source))
     return quicksortFloatsIndirect(index, source, 0, index.length - 1);
   return quicksortIndirect(index, source, 0, index.length - 1);
@@ -246,16 +280,12 @@ export function sortIndex(index: any, source: any) {
 //    C++: lower_bound()
 //    Python: bisect.bisect_left()
 //
-function lowerBoundNonFloat(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+function lowerBoundNonFloat<T extends NonFloatSortableArray>(
+  valueArray: T,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   let lfirst = first;
   let llast = last;
   // this is just a binary search
@@ -275,8 +305,12 @@ function lowerBoundNonFloat(
 // If the underlying array is a Float32Array or Float64Array, will enforce
 // the ordering -Infinity < finite < Infinity < NaN.
 //
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function lowerBoundFloat(valueArray: any, value: any, first: any, last: any) {
+function lowerBoundFloat(
+  valueArray: FloatTypedArray,
+  value: number,
+  first: number,
+  last: number
+): number {
   let lfirst = first;
   let llast = last;
   // this is just a binary search
@@ -291,28 +325,28 @@ function lowerBoundFloat(valueArray: any, value: any, first: any, last: any) {
   return lfirst;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function lowerBound(valueArray: any, value: any, first: any, last: any) {
+export function lowerBound<T extends SortableArray>(
+  valueArray: T,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   if (isFloatTypedArray(valueArray)) {
-    return lowerBoundFloat(valueArray, value, first, last);
+    // TSC is not able to infer that T[0] is a number, so we revert to a cast
+    return lowerBoundFloat(valueArray, value as number, first, last);
   }
   return lowerBoundNonFloat(valueArray, value, first, last);
 }
 
 // Inlined performance optimization - used to indirect through a sort map.
 //
-function lowerBoundNonFloatIndirect(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  indexArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+function lowerBoundNonFloatIndirect<T extends NonFloatSortableArray>(
+  valueArray: T,
+  indexArray: IndexArray,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   let lfirst = first;
   let llast = last;
   // this is just a binary search
@@ -328,17 +362,12 @@ function lowerBoundNonFloatIndirect(
 }
 
 function lowerBoundFloatIndirect(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  indexArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+  valueArray: FloatTypedArray,
+  indexArray: IndexArray,
+  value: number,
+  first: number,
+  last: number
+): number {
   let lfirst = first;
   let llast = last;
   // this is just a binary search
@@ -353,21 +382,21 @@ function lowerBoundFloatIndirect(
   return lfirst;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export function lowerBoundIndirect(
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  indexArray: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+export function lowerBoundIndirect<T extends SortableArray>(
+  valueArray: T,
+  indexArray: IndexArray,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   if (isFloatTypedArray(valueArray)) {
-    return lowerBoundFloatIndirect(valueArray, indexArray, value, first, last);
+    return lowerBoundFloatIndirect(
+      valueArray,
+      indexArray,
+      value as number, // TSC is not able to infer that T[0] is a number, so we revert to a cast
+      first,
+      last
+    );
   }
   return lowerBoundNonFloatIndirect(valueArray, indexArray, value, first, last);
 }
@@ -383,16 +412,12 @@ export function lowerBoundIndirect(
 //    C++: upper_bound()
 //    Python: bisect.bisect_right()
 //
-function upperBoundNonFloat(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+function upperBoundNonFloat<T extends NonFloatSortableArray>(
+  valueArray: T,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   let lfirst = first;
   let llast = last;
   // this is just a binary search
@@ -407,8 +432,12 @@ function upperBoundNonFloat(
   return lfirst;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-function upperBoundFloat(valueArray: any, value: any, first: any, last: any) {
+function upperBoundFloat(
+  valueArray: FloatTypedArray,
+  value: number,
+  first: number,
+  last: number
+): number {
   let lfirst = first;
   let llast = last;
   // this is just a binary search
@@ -423,28 +452,28 @@ function upperBoundFloat(valueArray: any, value: any, first: any, last: any) {
   return lfirst;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function upperBound(valueArray: any, value: any, first: any, last: any) {
+export function upperBound<T extends SortableArray>(
+  valueArray: T,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   if (isFloatTypedArray(valueArray)) {
-    return upperBoundFloat(valueArray, value, first, last);
+    // TSC is not able to infer that T[0] is a number, so we revert to a cast
+    return upperBoundFloat(valueArray, value as number, first, last);
   }
   return upperBoundNonFloat(valueArray, value, first, last);
 }
 
 // Inline performance optimization
 //
-function upperBoundNonFloatIndirect(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  indexArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+function upperBoundNonFloatIndirect<T extends NonFloatSortableArray>(
+  valueArray: T,
+  indexArray: IndexArray,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   let lfirst = first;
   let llast = last;
   // this is just a binary search
@@ -460,17 +489,12 @@ function upperBoundNonFloatIndirect(
 }
 
 function upperBoundFloatIndirect(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  indexArray: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+  valueArray: FloatTypedArray,
+  indexArray: IndexArray,
+  value: number,
+  first: number,
+  last: number
+): number {
   let lfirst = first;
   let llast = last;
   // this is just a binary search
@@ -485,21 +509,22 @@ function upperBoundFloatIndirect(
   return lfirst;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export function upperBoundIndirect(
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  indexArray: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+export function upperBoundIndirect<T extends SortableArray>(
+  valueArray: T,
+  indexArray: IndexArray,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   if (isFloatTypedArray(valueArray)) {
-    return upperBoundFloatIndirect(valueArray, indexArray, value, first, last);
+    // TSC is not able to infer that T[0] is a number, so we revert to a cast
+    return upperBoundFloatIndirect(
+      valueArray,
+      indexArray,
+      value as number,
+      first,
+      last
+    );
   }
   return upperBoundNonFloatIndirect(valueArray, indexArray, value, first, last);
 }
@@ -511,17 +536,12 @@ export function upperBoundIndirect(
 // The same semantics/behavior as:
 //    C++: binary_search()
 //
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
-export function binarySearch(
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  valueArray: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  first: any,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  last: any
-) {
+export function binarySearch<T extends SortableArray>(
+  valueArray: T,
+  value: T[0],
+  first: number,
+  last: number
+): number {
   const index = lowerBound(valueArray, value, first, last);
   if (index !== last && value === valueArray[index]) return index;
   return last;

--- a/client/src/util/typedCrossfilter/types.ts
+++ b/client/src/util/typedCrossfilter/types.ts
@@ -9,7 +9,6 @@ import {
 /**
  * Cross-filter shared types.
  */
-
 export type NonFloatSortableArray =
   | Array<number | string | boolean>
   | IntTypedArray

--- a/client/src/util/typedCrossfilter/types.ts
+++ b/client/src/util/typedCrossfilter/types.ts
@@ -1,0 +1,96 @@
+import {
+  TypedArray,
+  SortableArray,
+  NumberArrayConstructor,
+  IntTypedArray,
+  UnsignedIntTypedArray,
+} from "../../common/types/arraytypes";
+
+/**
+ * Cross-filter shared types.
+ */
+
+export type NonFloatSortableArray =
+  | Array<number | string | boolean>
+  | IntTypedArray
+  | UnsignedIntTypedArray;
+export type IndexArray = Uint32Array;
+
+/**
+ * Crossfilter selection - see Crossfilter.select()
+ */
+type SelectableValue = string | number;
+export enum SelectionMode {
+  All = "all",
+  None = "none",
+  Exact = "exact",
+  Range = "range",
+  WithinRect = "within-rect",
+  WithinPolygon = "within-polygon",
+}
+
+export interface SelectAll {
+  mode: SelectionMode.All | "all";
+}
+
+export interface SelectNone {
+  mode: SelectionMode.None | "none";
+}
+
+export interface SelectExact {
+  mode: SelectionMode.Exact | "exact";
+  values: SelectableValue | SelectableValue[];
+}
+
+export interface SelectRange {
+  mode: SelectionMode.Range | "range";
+  inclusive?: boolean;
+  lo: SelectableValue;
+  hi: SelectableValue;
+}
+
+export interface SelectWithinRect {
+  mode: SelectionMode.WithinRect | "within-rect";
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+export interface SelectWithinPolygon {
+  mode: SelectionMode.WithinPolygon | "within-polygon";
+  polygon: [number, number][];
+}
+
+export type CrossfilterSelector =
+  | SelectAll
+  | SelectNone
+  | SelectExact
+  | SelectRange
+  | SelectWithinRect
+  | SelectWithinPolygon;
+
+/**
+ * Add dimension to crossfilter - see Crossfilter.addDimension()
+ */
+export interface ScalarDimensionParameters {
+  type: "scalar";
+  ValueArrayCtor?: NumberArrayConstructor;
+  value: SortableArray;
+}
+
+export interface EnumDimensionParameters {
+  type: "enum";
+  value: SortableArray;
+}
+
+export interface SpatialDimensionParameters {
+  type: "spatial";
+  X: TypedArray;
+  Y: TypedArray;
+}
+
+export type CrossfilterDimensionParameters =
+  | ScalarDimensionParameters
+  | EnumDimensionParameters
+  | SpatialDimensionParameters;

--- a/client/src/util/typedCrossfilter/util.ts
+++ b/client/src/util/typedCrossfilter/util.ts
@@ -1,27 +1,25 @@
 import { sortIndex } from "./sort";
 import { rangeFill as fillRange } from "../range";
+import { SortableArray } from "../../common/types/arraytypes";
+import { IndexArray } from "./types";
 
 /*
     Utility functions, private to this module.
 */
 
-// slice out of one array into another, using an index array
-//
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function sliceByIndex(src: any, index: any) {
-  if (index === undefined || index === null) {
-    return src;
-  }
-  const dst = new src.constructor(index.length);
-  for (let i = 0; i < index.length; i += 1) {
-    dst[i] = src[index[i]];
-  }
-  return dst;
-}
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-export function makeSortIndex(src: any) {
+export function makeSortIndex(src: SortableArray): IndexArray {
   const index = fillRange(new Uint32Array(src.length));
   sortIndex(index, src);
   return index;
+}
+
+export class NotImplementedError extends Error {
+  constructor(msg: string) {
+    super(msg);
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, NotImplementedError);
+    }
+  }
 }


### PR DESCRIPTION
This PR primarily adds TS typing for the crossfilter which is the last item in chanzuckerberg/cellxgene#2366
.  In addition:
* second pass through Dataframe and AnnoMatrix for additional cleanup (chanzuckerberg/cellxgene#2394)
* pulled typing through users of these API (eg, src/actions/annotations.ts)
* utils lint chanzuckerberg/cellxgene#2388

Fixes chanzuckerberg/cellxgene#2394
Fixes chanzuckerberg/cellxgene#2366
Fixes chanzuckerberg/cellxgene#2388
