### PR TITLE
Dunitz/cache deletion error

### DIFF
--- a/backend/czi_hosted/data_common/cache.py
+++ b/backend/czi_hosted/data_common/cache.py
@@ -181,11 +181,11 @@ class CacheManager(object):
                         create_data_function=create_data_function,
                         create_data_args=create_data_args
                     )
-                    cache_item_info.cache_item = cache_item
                 except (DatasetNotFoundError, DatasetAccessError) as e:
                     cache_item_info.error = e
                     raise
                 finally:
+                    cache_item_info.cache_item = cache_item
                     self.data[cache_key] = cache_item_info
 
         try:

--- a/backend/test/test_czi_hosted/unit/common/utils/test_cache.py
+++ b/backend/test/test_czi_hosted/unit/common/utils/test_cache.py
@@ -248,25 +248,42 @@ class CacheManagerTest(unittest.TestCase):
         cache_manager = CacheManager(max_cached=3, timelimit_s=self.CACHE_TIME_LIMIT)
         mock_get_data_raises_error = Mock(side_effect=DatasetNotFoundError(f"Dataset location not found for this guy"))
         with self.assertRaises(DatasetNotFoundError):
-            with cache_manager.get("key_one", mock_get_data_raises_error) as cache_item:
-                self.assertIsNotNone(cache_item)
-                self.assertIsNotNone(cache_item.error)
-                self.assertIsNone(cache_item.data)
-                self.assertEqual(cache_item.error, DatasetNotFoundError)
+            with cache_manager.get("key_one", mock_get_data_raises_error) as cache_item_info:
+                self.assertIsNotNone(cache_item_info)
+                self.assertIsNotNone(cache_item_info.error)
+                self.assertIsNone(cache_item_info.cache_item.data)
+                self.assertEqual(cache_item_info.error, DatasetNotFoundError)
 
     def test_cache_manager_doesnt_try_to_retrieve_data_for_cache_items_with_errors(self):
         cache_manager = CacheManager(max_cached=3, timelimit_s=self.CACHE_TIME_LIMIT)
         mock_get_data_raises_error = Mock(side_effect=DatasetNotFoundError(f"Dataset location not found for this guy"))
         with self.assertRaises(DatasetNotFoundError):
-            with cache_manager.get("key_one", mock_get_data_raises_error) as cache_item:
-                self.assertIsNotNone(cache_item)
-                self.assertIsNotNone(cache_item.error)
-                self.assertIsNone(cache_item.data)
-                self.assertEqual(cache_item.error, DatasetNotFoundError)
+            with cache_manager.get("key_one", mock_get_data_raises_error) as cache_item_info:
+                self.assertIsNotNone(cache_item_info)
+                self.assertIsNotNone(cache_item_info.error)
+                self.assertIsNone(cache_item_info.cache_item.data)
+                self.assertEqual(cache_item_info.error, DatasetNotFoundError)
 
         # This should reraise the exception without recalling the get data function
         with self.assertRaises(DatasetNotFoundError):
-            with cache_manager.get("key_one", mock_get_data_raises_error) as cache_item:
-                self.assertEqual(cache_item.error, DatasetNotFoundError)
+            with cache_manager.get("key_one", mock_get_data_raises_error) as cache_item_info:
+                self.assertEqual(cache_item_info.error, DatasetNotFoundError)
 
         self.assertEqual(mock_get_data_raises_error.call_count, 1)
+
+
+    def test_cache_manager_can_delete_cache_items_with_errors(self):
+        cache_manager = CacheManager(max_cached=3, timelimit_s=self.CACHE_TIME_LIMIT)
+        mock_get_data_raises_error = Mock(side_effect=DatasetNotFoundError(f"Dataset location not found for this guy"))
+        with self.assertRaises(DatasetNotFoundError):
+            with cache_manager.get("key_one", mock_get_data_raises_error) as cache_item_info:
+                self.assertIsNotNone(cache_item_info)
+                self.assertIsNotNone(cache_item_info.error)
+                self.assertIsNone(cache_item_info.cache_item.data)
+                self.assertEqual(cache_item_info.error, DatasetNotFoundError)
+        sleep(self.CACHE_TIME_LIMIT + 1)
+        # Retrieving a different cache item should trigger the data expiration policy which should delete "key_one" item
+        with cache_manager.get("key_two", lambda x: {x: x}) as cache_item_info:
+            self.assertIsNotNone(cache_item_info)
+
+


### PR DESCRIPTION
#### Reviewers
**Functional:** 
- @ebezzi 
**Readability:** 

---

## Changes
- add test that fails for current code with the error seen in the staging environment (`AttributeError: 'NoneType' object has no attribute 'attempt_delete'`)
- modify cache item creation code to create a cache item even when the dataset raises an error to simplify the code for cache eviction (which fixes the failing test described above). 
This is to address a bug found in the latests staging deploy. See discussion in slack https://czi-sci.slack.com/archives/C0244PQK934/p1630614658016400 for more detail
