### PR TITLE
fix: implemented temporary workaround suggested by TileDB. (#2251)

### DIFF
--- a/server/compute/diffexp_cxg.py
+++ b/server/compute/diffexp_cxg.py
@@ -87,16 +87,11 @@ def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
 
     if is_sparse:
         for cols in col_partitions:
-            futures.append(
-                executor.submit(
-                    _mean_var_sparse_ab,
-                    adaptor.open_array("X"), row_selector_A, nA, row_selector_B, nB, cols))
+            futures.append(executor.submit(_mean_var_sparse_ab, matrix, row_selector_A, nA, row_selector_B, nB, cols))
     else:
         for cols in col_partitions:
             futures.append(
-                executor.submit(
-                    _mean_var_ab,
-                    adaptor.open_array("X"), row_selector_AB, row_selector_A_in_AB, row_selector_B_in_AB, cols)
+                executor.submit(_mean_var_ab, matrix, row_selector_AB, row_selector_A_in_AB, row_selector_B_in_AB, cols)
             )
 
     for future in futures:

--- a/server/compute/diffexp_cxg.py
+++ b/server/compute/diffexp_cxg.py
@@ -87,11 +87,11 @@ def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
 
     if is_sparse:
         for cols in col_partitions:
-            futures.append(executor.submit(_mean_var_sparse_ab, matrix, row_selector_A, nA, row_selector_B, nB, cols))
+            futures.append(executor.submit(_mean_var_sparse_ab, adaptor.open_array("X"), row_selector_A, nA, row_selector_B, nB, cols))
     else:
         for cols in col_partitions:
             futures.append(
-                executor.submit(_mean_var_ab, matrix, row_selector_AB, row_selector_A_in_AB, row_selector_B_in_AB, cols)
+                executor.submit(_mean_var_ab, adaptor.open_array("X"), row_selector_AB, row_selector_A_in_AB, row_selector_B_in_AB, cols)
             )
 
     for future in futures:

--- a/server/compute/diffexp_cxg.py
+++ b/server/compute/diffexp_cxg.py
@@ -87,11 +87,16 @@ def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
 
     if is_sparse:
         for cols in col_partitions:
-            futures.append(executor.submit(_mean_var_sparse_ab, adaptor.open_array("X"), row_selector_A, nA, row_selector_B, nB, cols))
+            futures.append(
+                executor.submit(
+                    _mean_var_sparse_ab,
+                    adaptor.open_array("X"), row_selector_A, nA, row_selector_B, nB, cols))
     else:
         for cols in col_partitions:
             futures.append(
-                executor.submit(_mean_var_ab, adaptor.open_array("X"), row_selector_AB, row_selector_A_in_AB, row_selector_B_in_AB, cols)
+                executor.submit(
+                    _mean_var_ab,
+                    adaptor.open_array("X"), row_selector_AB, row_selector_A_in_AB, row_selector_B_in_AB, cols)
             )
 
     for future in futures:

--- a/server/data_cxg/cxg_adaptor.py
+++ b/server/data_cxg/cxg_adaptor.py
@@ -195,7 +195,12 @@ class CxgAdaptor(DataAdaptor):
     def open_array(self, name):
         try:
             p = self.get_path(name)
-            return self.arrays[p]
+            # TODO: remove this temporary workaround when TileDB fixes the issue with multi_index
+            if name == "X" or name == "X_col_shift":
+                # workaround: bypass the cache for arrays that use multi_index
+                return CxgAdaptor._open_array(p, self.tiledb_ctx)
+            else:
+                return self.arrays[p]
         except tiledb.libtiledb.TileDBError:
             raise DatasetAccessError(name)
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,6 @@ pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pand
 PyYAML>=5.4  # CVE-2020-14343
 scipy>=1.4
 requests>=2.22.0
-tiledb>=0.9
+tiledb==0.10.0
 s3fs==0.4.2
 sqlalchemy>=1.3.18


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@bkmartinjr, @MDunitz 

**Readability:** 
@ebezzi 

---

## Changes
- modify: TileDB-Py version 0.9.5 -> 0.10.0 plus workaround for threading issue

## Reviewer Notes
* Bruce provided a [bug repro](https://czi-sci.slack.com/archives/C013K0JB8F8/p1631313728008100) to TileDB which showed that the failure occurs on TileDB-Py versions 0.8.8 and above, including the current version, 0.10.0.
* This temporary workaround was [suggested by Seth](https://czi-sci.slack.com/archives/C013K0JB8F8/p1631314319012700) from TileDB and refined by Bruce to avoid hitting the cached `X` and `X_col_shift` arrays. 