### PR TITLE
fix: upgraded tiledb and reverted workaround (#61)

### DIFF
--- a/server/compute/diffexp_cxg.py
+++ b/server/compute/diffexp_cxg.py
@@ -87,24 +87,11 @@ def diffexp_ttest(adaptor, maskA, maskB, top_n=8, diffexp_lfc_cutoff=0.01):
 
     if is_sparse:
         for cols in col_partitions:
-            futures.append(
-                executor.submit(
-                    # TODO: remove this temporary workaround when TileDB fixes the issue with multi_index
-                    _mean_var_sparse_ab, adaptor.open_array("X"), row_selector_A, nA, row_selector_B, nB, cols
-                )
-            )
+            futures.append(executor.submit(_mean_var_sparse_ab, matrix, row_selector_A, nA, row_selector_B, nB, cols))
     else:
         for cols in col_partitions:
             futures.append(
-                executor.submit(
-                    _mean_var_ab,
-                    # TODO: remove this temporary workaround when TileDB fixes the issue with multi_index
-                    adaptor.open_array("X"),
-                    row_selector_AB,
-                    row_selector_A_in_AB,
-                    row_selector_B_in_AB,
-                    cols,
-                )
+                executor.submit(_mean_var_ab, matrix, row_selector_AB, row_selector_A_in_AB, row_selector_B_in_AB, cols)
             )
 
     for future in futures:

--- a/server/data_cxg/cxg_adaptor.py
+++ b/server/data_cxg/cxg_adaptor.py
@@ -195,12 +195,7 @@ class CxgAdaptor(DataAdaptor):
     def open_array(self, name):
         try:
             p = self.get_path(name)
-            # TODO: remove this temporary workaround when TileDB fixes the issue with multi_index
-            if name == "X" or name == "X_col_shift":
-                # workaround: bypass the cache for arrays that use multi_index
-                return CxgAdaptor._open_array(p, self.tiledb_ctx)
-            else:
-                return self.arrays[p]
+            return self.arrays[p]
         except tiledb.libtiledb.TileDBError:
             raise DatasetAccessError(name)
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,6 @@ pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pand
 PyYAML>=5.4  # CVE-2020-14343
 scipy>=1.4
 requests>=2.22.0
-tiledb==0.10.0
+tiledb==0.10.1
 s3fs==0.4.2
 sqlalchemy>=1.3.18


### PR DESCRIPTION
#### Reviewers
**Functional:** 
- @bkmartinjr 
- @MDunitz 

**Readability:** 
- @ebezzi 

---

## Changes
- remove: workaround code introduced by #58 and #60
- modify: upgraded [TileDB-Py to 0.10.1](https://github.com/TileDB-Inc/TileDB-Py/releases/tag/0.10.1) which includes the fix for the [`Array.multi_index` concurrency bug](https://github.com/TileDB-Inc/TileDB-Py/pull/672).

## QA
- verified by reproducing the crash locally on 0.10.0 and without the workaround code, upgrading to 0.10.1 and running the same diffexp against the same dataset multiple times crash free
- will run the same tests once deployed to staging