### PR TITLE
chore: 1210 Add Plausible

### DIFF
--- a/client/__tests__/e2e/screenshot_env.js
+++ b/client/__tests__/e2e/screenshot_env.js
@@ -1,11 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const PuppeteerEnvironment = require("jest-environment-puppeteer");
 require("jest-circus");
-// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const ENV_DEFAULT = require("../../../environment.default.json");
-
-// @ts-expect-error ts-migrate(2451) FIXME: Cannot redeclare block-scoped variable 'takeScreen... Remove this comment to see the full error message
-// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const takeScreenshot = require("./takeScreenshot");
 
 class ScreenshotEnvironment extends PuppeteerEnvironment {

--- a/client/configuration/eslint/eslint.js
+++ b/client/configuration/eslint/eslint.js
@@ -106,6 +106,13 @@ module.exports = {
     ],
   },
   overrides: [
+    // Override some TypeScript rules just for .js files
+    {
+      files: ["*.js"],
+      rules: {
+        "@typescript-eslint/no-var-requires": "off",
+      },
+    },
     {
       files: ["**/*.test.ts"],
       env: {

--- a/client/configuration/webpack/webpack.config.shared.js
+++ b/client/configuration/webpack/webpack.config.shared.js
@@ -1,14 +1,10 @@
 /* eslint-disable @blueprintjs/classes-constants -- we don't import blueprint here  */
-// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const path = require("path");
-// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const fs = require("fs");
-// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const ObsoleteWebpackPlugin = require("obsolete-webpack-plugin");
-// eslint-disable-next-line @typescript-eslint/no-var-requires --- FIXME: disabled temporarily on migrate to TS.
 const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
+const webpack = require("webpack");
 
 const src = path.resolve("src");
 const nodeModules = path.resolve("node_modules");
@@ -21,6 +17,8 @@ const rawObsoleteHTMLTemplate = fs.readFileSync(
 );
 
 const obsoleteHTMLTemplate = rawObsoleteHTMLTemplate.replace(/'/g, '"');
+
+const deploymentStage = process.env.DEPLOYMENT_STAGE || "test";
 
 module.exports = {
   entry: [
@@ -77,6 +75,13 @@ module.exports = {
     }),
     new ScriptExtHtmlWebpackPlugin({
       async: "obsolete",
+    }),
+    new webpack.DefinePlugin({
+      PLAUSIBLE_DATA_DOMAIN: JSON.stringify(
+        deploymentStage === "prod"
+          ? "cellxgene.cziscience.com"
+          : "cellxgene.staging.single-cell.czi.technology"
+      ),
     }),
   ],
 };

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -34,6 +34,11 @@
         box-sizing: border-box;
       }
     </style>
+    <script
+      defer
+      data-domain="<%= PLAUSIBLE_DATA_DOMAIN %>"
+      src="https://plausible.io/js/plausible.js"
+    ></script>
   </head>
   <body>
     <script type="text/javascript">

--- a/server/eb/app.py
+++ b/server/eb/app.py
@@ -55,10 +55,13 @@ class WSGIServer(Server):
         # this should print the failing script's hash to console.
         # See more here: https://github.com/chanzuckerberg/cellxgene/pull/1745
         obsolete_browser_script_hash = ["'sha256-/rmgOi/skq9MpiZxPv6lPb1PNSN+Uf4NaUHO/IjyfwM='"]
+
+        PLAUSIBLE_URL = "https://plausible.io"
+
         csp = {
             "default-src": ["'self'"],
-            "connect-src": ["'self'"] + extra_connect_src,
-            "script-src": ["'self'", "'unsafe-eval'"] + obsolete_browser_script_hash + script_hashes,
+            "connect-src": ["'self'", PLAUSIBLE_URL] + extra_connect_src,
+            "script-src": ["'self'", "'unsafe-eval'", PLAUSIBLE_URL] + obsolete_browser_script_hash + script_hashes,
             "style-src": ["'self'", "'unsafe-inline'"],
             "img-src": ["'self'", "https://cellxgene.cziscience.com", "data:"],
             "object-src": ["'none'"],


### PR DESCRIPTION
#### Reviewers
https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-data-portal/1210

**Functional:** 
@seve 

**Readability:** 
@MDunitz 

---

## Changes
This PR adds Plausible script to `client/index_template.html`, and we change Plausible's `data-domain` attribute based on `DEPLOYMENT_STAGE` env value

BONUS:
This PR also updates ESLint to ignore `no var require` rule in `.js` files, since it's false positive

There's a [complementary Infra PR](https://github.com/chanzuckerberg/single-cell-infra/pull/434) that I think is needed in order for FE build step to get `DEPLOYMENT_STAGE`

PTAL thank you!