### PR TITLE
Fix #104 dataframe histogram memoization

### DIFF
--- a/client/src/util/dataframe/dataframe.ts
+++ b/client/src/util/dataframe/dataframe.ts
@@ -251,6 +251,22 @@ class Dataframe {
     const { length } = column;
     const __id = __getMemoId();
     const isContinuous = isTypedArray(column);
+    const memoHistogramContinuous = memoize(
+      _histogramContinuous,
+      hashContinuous
+    );
+    const memoHistogramContinuousBy = memoize(
+      _histogramContinuousBy,
+      hashContinuousBy
+    );
+    const memoHistogramCategorical = memoize(
+      _histogramCategorical,
+      hashCategorical
+    );
+    const memoHistogramCategoricalBy = memoize(
+      _histogramCategoricalBy,
+      hashCategoricalBy
+    );
 
     /* get value by row label */
     const get = function get(rlabel: LabelType): DataframeValue | undefined {
@@ -311,7 +327,7 @@ class Dataframe {
     */
     get.histogramContinuous = isContinuous
       ? (bins: number, domain: [number, number]): ContinuousHistogram =>
-          memoize(_histogramContinuous, hashContinuous)(get, bins, domain)
+          memoHistogramContinuous(get, bins, domain)
       : raiseIsNotContinuous;
     get.histogramContinuousBy = isContinuous
       ? (
@@ -319,17 +335,11 @@ class Dataframe {
           domain: [number, number],
           by: DataframeColumn
         ): ContinuousHistogramBy =>
-          memoize(_histogramContinuousBy, hashContinuousBy)(
-            get,
-            bins,
-            domain,
-            by
-          )
+          memoHistogramContinuousBy(get, bins, domain, by)
       : raiseIsNotContinuous;
-    get.histogramCategorical = () =>
-      memoize(_histogramCategorical, hashCategorical)(get);
+    get.histogramCategorical = () => memoHistogramCategorical(get);
     get.histogramCategoricalBy = (by: DataframeColumn) =>
-      memoize(_histogramCategoricalBy, hashCategoricalBy)(get, by);
+      memoHistogramCategoricalBy(get, by);
 
     get.asArray = asArray;
     get.has = has;


### PR DESCRIPTION
Memo was being set up on every call rather than once per instance, causing some UI features to be slow
e.g. https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell-explorer/104.

These were the only instances of memo not working correctly that I could find. Also, this issue does not affect cellxgene desktop as the bug was introduced during the TS migration.

Perf screenshots when clicking a CatVar drop down (following the steps to reproduce above).
Before
![Screen Shot 2021-10-06 at 9 55 37 AM](https://user-images.githubusercontent.com/4804047/136250716-4121038b-8aa3-4da9-986c-0925a4420798.png)

After
![Screen Shot 2021-10-06 at 9 53 51 AM](https://user-images.githubusercontent.com/4804047/136250730-93d970fe-dafc-47cc-98ee-4d43f34c07d9.png)


#### Reviewers
**Functional:** 
Bruce
**Readability:** 
Seve
---

## Changes
* Fix memoization for dataframe's histogram functions

