### PR TITLE
Added WIP check for home and collection links. (#124)

### DIFF
--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -292,7 +292,7 @@ const requestDifferentialExpression =
 /**
  * Check local storage for flag indicating that the work in progress toast should be displayed.
  */
-export const checkExplainNewTab =
+const checkExplainNewTab =
   () =>
   (dispatch: AppDispatch): void => {
     const workInProgressWarn = storageGetTransient(KEYS.WORK_IN_PROGRESS_WARN);
@@ -305,11 +305,26 @@ export const checkExplainNewTab =
   };
 
 /**
+ * Navigate to URL in the same browser tab if there is no work in progress, otherwise open URL in new tab.
+ * @param url - URL to navigate to.
+ */
+const navigateCheckUserState =
+  (url: string): ((dispatch: AppDispatch, getState: GetState) => void) =>
+  (_dispatch: AppDispatch, getState: GetState) => {
+    const workInProgress = selectIsUserStateDirty(getState());
+    if (workInProgress) {
+      openTab(url);
+    } else {
+      window.location.href = url;
+    }
+  };
+
+/**
  * Handle select of dataset from dataset selector: determine whether to display dataset in current browser tab or open
  * dataset in new tab if user currently has work in progress.
  * @param dataset Dataset to switch to and load in the current tab.
  */
-export const selectDataset =
+const selectDataset =
   (dataset: Dataset): ((dispatch: AppDispatch, getState: GetState) => void) =>
   (dispatch: AppDispatch, getState: GetState) => {
     const workInProgress = selectIsUserStateDirty(getState());
@@ -335,8 +350,16 @@ const openDataset =
 
     dispatch({ type: "dataset opened" });
     storageSetTransient(KEYS.WORK_IN_PROGRESS_WARN, 10000);
-    window.open(deploymentUrl, "_blank", "noopener");
+    openTab(deploymentUrl);
   };
+
+/**
+ * Open new tab and navigate to the given URL.
+ * @param url - URL to navigate to.
+ */
+const openTab = (url: string) => {
+  window.open(url, "_blank", "noopener");
+};
 
 /**
  * Open selected dataset in a new tab.
@@ -348,7 +371,7 @@ const switchDataset =
     dispatch({ type: "reset" });
     dispatch({ type: "dataset switch" });
 
-    const deploymentUrl = dataset.dataset_deployments?.[0].url ?? "";
+    const deploymentUrl = dataset.dataset_deployments?.[0].url;
     if (!deploymentUrl) {
       dispatchNetworkErrorMessageToUser("Unable to switch datasets.");
       return;
@@ -379,6 +402,7 @@ export default {
   requestSingleGeneExpressionCountsForColoringPOST,
   requestUserDefinedGene,
   checkExplainNewTab,
+  navigateCheckUserState,
   selectDataset,
   selectContinuousMetadataAction: selnActions.selectContinuousMetadataAction,
   selectCategoricalMetadataAction: selnActions.selectCategoricalMetadataAction,

--- a/client/src/components/app.tsx
+++ b/client/src/components/app.tsx
@@ -16,7 +16,7 @@ import MenuBar from "./menubar";
 import Autosave from "./autosave";
 import Embedding from "./embedding";
 
-import actions, { checkExplainNewTab } from "../actions";
+import actions from "../actions";
 import { RootState, AppDispatch } from "../reducers";
 
 interface Props {
@@ -33,7 +33,7 @@ class App extends React.Component<Props> {
     window.addEventListener("popstate", this._onURLChanged);
     this._onURLChanged();
     dispatch(actions.doInitialDataLoad());
-    dispatch(checkExplainNewTab());
+    dispatch(actions.checkExplainNewTab());
     this.forceUpdate();
   }
 

--- a/client/src/components/datasetSelector/datasetSelector.tsx
+++ b/client/src/components/datasetSelector/datasetSelector.tsx
@@ -5,7 +5,7 @@ import React, { FC, useEffect, useState } from "react";
 import { connect } from "react-redux";
 
 /* App dependencies */
-import { selectDataset } from "../../actions";
+import actions from "../../actions";
 import { DatasetMetadata, Dataset } from "../../common/types/entities";
 import DatasetMenu, { DatasetSelectedFn } from "./datasetMenu";
 import { AppDispatch, RootState } from "../../reducers";
@@ -19,8 +19,14 @@ import TruncatingBreadcrumbs, {
  * Actions dispatched by dataset selector.
  */
 interface DispatchProps {
+  navigateCheckUserState: NavigateCheckUserState;
   selectDataset: DatasetSelectedFn;
 }
+
+/**
+ * Function called on click of home and collection links.
+ */
+export type NavigateCheckUserState = (url: string) => void;
 
 /**
  * Props selected from store.
@@ -46,7 +52,9 @@ const mapStateToProps = (state: RootState): StateProps => ({
  * Map actions dispatched by dataset selector to props.
  */
 const mapDispatchToProps = (dispatch: AppDispatch): DispatchProps => ({
-  selectDataset: (dataset: Dataset) => dispatch(selectDataset(dataset)),
+  selectDataset: (dataset: Dataset) => dispatch(actions.selectDataset(dataset)),
+  navigateCheckUserState: (url: string) =>
+    dispatch(actions.navigateCheckUserState(url)),
 });
 
 // Inline styles for icons
@@ -60,6 +68,7 @@ const DatasetSelector: FC<Props> = ({
   portalUrl,
   seamlessEnabled,
   selectDataset: selectDatasetFn,
+  navigateCheckUserState: navigateCheckUserStateFn,
 }) => {
   // Datasets that are siblings of the selected dataset
   const [siblingDatasets, setSiblingDatasets] = useState<Dataset[]>([]);
@@ -83,8 +92,8 @@ const DatasetSelector: FC<Props> = ({
 
     // Build props backing breadcrumbs
     setItems([
-      buildHomeBreadcrumbProps(portalUrl),
-      buildCollectionBreadcrumbProps(datasetMetadata),
+      buildHomeBreadcrumbProps(portalUrl, navigateCheckUserStateFn),
+      buildCollectionBreadcrumbProps(datasetMetadata, navigateCheckUserStateFn),
       buildDatasetBreadcrumbProps(
         datasetMetadata.dataset_name,
         isDatasetSingleton(datasets)
@@ -148,13 +157,15 @@ function buildDatasetBreadcrumbProps(
 /**
  * Build "collection" breadcrumb props, links to Portal's collection detail page.
  * @param datasetMetadata - Dataset metadata containing collection information.
+ * @param navigateCheckUserStateFn - Function called on click of collection breadcrumb.
  * @returns Returns breadcrumbs props for rendering the "collection" breadcrumb.
  */
 function buildCollectionBreadcrumbProps(
-  datasetMetadata: DatasetMetadata
+  datasetMetadata: DatasetMetadata,
+  navigateCheckUserStateFn: NavigateCheckUserState
 ): TruncatingBreadcrumbProps {
   return {
-    href: datasetMetadata.collection_url,
+    onClick: () => navigateCheckUserStateFn(datasetMetadata.collection_url),
     shortText: "Collection",
     text: datasetMetadata.collection_name,
   };
@@ -163,13 +174,15 @@ function buildCollectionBreadcrumbProps(
 /**
  * Build "home" breadcrumb props, links to Portal's collection index page.
  * @param portalUrl - URL to Portal's collection index page.
+ * @param navigateCheckUserStateFn - Function called on click of home breadcrumb.
  * @returns Returns breadcrumbs props for rendering the "home" breadcrumb.
  */
 function buildHomeBreadcrumbProps(
-  portalUrl: string
+  portalUrl: string,
+  navigateCheckUserStateFn: NavigateCheckUserState
 ): TruncatingBreadcrumbProps {
   return {
-    href: portalUrl,
+    onClick: () => navigateCheckUserStateFn(portalUrl),
     shortText: "Home",
     text: "Home",
   };
@@ -195,12 +208,12 @@ function renderBreadcrumb(item: TruncatingBreadcrumbProps): JSX.Element {
 
 /**
  * Clicking on dataset name opens menu containing all dataset names except the current dataset name for the current
- collection.
+ * collection.
  * @param item - Breadcrumb props to be rendered as a breadcrumb element with menu.
  * @param siblingDatasets - Datasets in the collection of the current dataset, except the selected dataset itself.
  * @param selectDatasetFn - Function invoked on click of dataset menu item.
  * @returns DatasetMenu element generated from given breadcrumb props and state.
-*/
+ */
 function renderBreadcrumbMenu(
   item: TruncatingBreadcrumbProps,
   siblingDatasets: Dataset[],

--- a/client/src/components/datasetSelector/truncatingBreadcrumb.tsx
+++ b/client/src/components/datasetSelector/truncatingBreadcrumb.tsx
@@ -21,6 +21,7 @@ const TruncatingBreadcrumb = React.memo<Props>(
   ({ item }): JSX.Element => (
     <Breadcrumb
       href={item.href}
+      onClick={item.disabled ? undefined : item.onClick}
       className={
         item.disabled
           ? styles.datasetSelectorBreadcrumbDisabled


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@seve, @ebezzi 

---

## Changes
* Updated home and collection breadcrumbs to open in new tab if there is user work in progress (that is, updates in the LSB or RSB).
* Linting of existing dataset selector-related actions.
