### PR TITLE
Filtered out large datasets. (#141)

### DIFF
--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -9,6 +9,9 @@ export const overflowCategoryLabel = ": all other labels";
 /* default "unassigned" value for user-created categorical metadata */
 export const unassignedCategoryLabel = "unassigned";
 
+/** Maximum number of cells a dataset can have in order to be included for display. */
+export const DATASET_MAX_CELL_COUNT = 200000;
+
 /**
  * Matches "/" followed by "ONE_OR_MORE_ANY_CHAR/ONE_OR_MORE_ANY_CHAR_EXCEPT_FORWARD_SLASH/" and ending with "api". Must
  * exclude forward slash to prevent matches on multiple path segments (e.g. /cellxgene/d/uuid.cxg).

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -10,7 +10,7 @@ export const overflowCategoryLabel = ": all other labels";
 export const unassignedCategoryLabel = "unassigned";
 
 /** Maximum number of cells a dataset can have in order to be included for display. */
-export const DATASET_MAX_CELL_COUNT = 200000;
+export const DATASET_MAX_CELL_COUNT = 2_000_000;
 
 /**
  * Matches "/" followed by "ONE_OR_MORE_ANY_CHAR/ONE_OR_MORE_ANY_CHAR_EXCEPT_FORWARD_SLASH/" and ending with "api". Must

--- a/client/src/util/stateManager/datasetMetadataHelpers.ts
+++ b/client/src/util/stateManager/datasetMetadataHelpers.ts
@@ -1,0 +1,19 @@
+/**
+ * Helper functions for binding dataset metadata.
+ */
+
+// App dependencies
+import { Dataset } from "../../common/types/entities";
+
+/**
+ * Filter out datasets that have cell counts greater than the given cell count limit.
+ * @param datasets - Array of datasets to filter.
+ * @param cellCountLimit - Maximum number of cells a dataset can have in order to be included for display.
+ * @returns Updated metadata with datasets with more than the given cell count limit filtered out.
+ */
+export function removeLargeDatasets(
+  datasets: Dataset[],
+  cellCountLimit: number
+): Dataset[] {
+  return datasets.filter((dataset) => dataset.cell_count <= cellCountLimit);
+}


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@tihuan, @ebezzi 

---

## Changes
- Filtered out large datasets (where cell count is greater than 2 million) on response from `/dataset-metadata`.
