### PR TITLE
Added param to Portal links if WIP. (#135)

### DIFF
--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -324,7 +324,7 @@ const navigateCheckUserState =
   (_dispatch: AppDispatch, getState: GetState) => {
     const workInProgress = selectIsUserStateDirty(getState());
     if (workInProgress) {
-      openTab(url);
+      openTab(`${url}?${globals.QUERY_PARAM_EXPLAIN_NEW_TAB}`);
     } else {
       window.location.href = url;
     }

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -12,6 +12,9 @@ export const unassignedCategoryLabel = "unassigned";
 /** Maximum number of cells a dataset can have in order to be included for display. */
 export const DATASET_MAX_CELL_COUNT = 2_000_000;
 
+/* Added to Portal links from breadcrumbs if there is work in progress */
+export const QUERY_PARAM_EXPLAIN_NEW_TAB = "explainNewTab";
+
 /**
  * Matches "/" followed by "ONE_OR_MORE_ANY_CHAR/ONE_OR_MORE_ANY_CHAR_EXCEPT_FORWARD_SLASH/" and ending with "api". Must
  * exclude forward slash to prevent matches on multiple path segments (e.g. /cellxgene/d/uuid.cxg).


### PR DESCRIPTION
### Reviewers
**Functional:** 
@tihuan 

---

## Changes
- Added `explainNewTab` query string param to Home and Collections links when user has work in progress, in order to pop corresponding toast in the Portal.

[Corresponding Data Portal PR](https://github.com/chanzuckerberg/single-cell-data-portal/pull/1555)