### PR TITLE
rm dataset metadata cache manager [#168]

### DIFF
--- a/server/common/config/server_config.py
+++ b/server/common/config/server_config.py
@@ -48,12 +48,6 @@ class ServerConfig(BaseConfig):
             self.multi_dataset__matrix_cache__timelimit_s = default_config["multi_dataset"]["matrix_cache"][
                 "timelimit_s"
             ]
-            self.multi_dataset__metadata_cache__max_datasets = default_config["multi_dataset"]["metadata_cache"][
-                "max_datasets"
-            ]
-            self.multi_dataset__metadata_cache__timelimit_s = default_config["multi_dataset"]["metadata_cache"][
-                "timelimit_s"
-            ]
 
             self.single_dataset__datapath = default_config["single_dataset"]["datapath"]
             self.single_dataset__obs_names = default_config["single_dataset"]["obs_names"]
@@ -78,9 +72,6 @@ class ServerConfig(BaseConfig):
 
         # The matrix data cache manager is created during the complete_config and stored here.
         self.matrix_data_cache_manager = None
-
-        # The dataset location cache manager is created during the complete_config and stored here.
-        self.dataset_metadata_cache_manager = None
 
     def complete_config(self, context):
         self.handle_app(context)
@@ -200,10 +191,6 @@ class ServerConfig(BaseConfig):
         if self.matrix_data_cache_manager is None:
             self.matrix_data_cache_manager = CacheManager(max_cached=1, timelimit_s=None)
 
-        # DatasetLocation cache is not necessary with a single dataset but using for code consistency
-        if self.dataset_metadata_cache_manager is None:
-            self.dataset_metadata_cache_manager = CacheManager(max_cached=1, timelimit_s=None)
-
         # preload this data set
         matrix_data_loader = MatrixDataLoader(location=self.single_dataset__datapath, app_config=self.app_config)
 
@@ -241,13 +228,9 @@ class ServerConfig(BaseConfig):
         self.validate_correct_type_of_configuration_attribute("multi_dataset__index", (type(None), bool, str))
         self.validate_correct_type_of_configuration_attribute("multi_dataset__allowed_matrix_types", list)
         self.validate_correct_type_of_configuration_attribute("multi_dataset__matrix_cache__max_datasets", int)
-        self.validate_correct_type_of_configuration_attribute("multi_dataset__metadata_cache__max_datasets", int)
 
         self.validate_correct_type_of_configuration_attribute(
             "multi_dataset__matrix_cache__timelimit_s", (type(None), int, float)
-        )
-        self.validate_correct_type_of_configuration_attribute(
-            "multi_dataset__metadata_cache__timelimit_s", (type(None), int, float)
         )
 
         if self.multi_dataset__dataroot is None:
@@ -297,12 +280,6 @@ class ServerConfig(BaseConfig):
             self.matrix_data_cache_manager = CacheManager(
                 max_cached=self.multi_dataset__matrix_cache__max_datasets,
                 timelimit_s=self.multi_dataset__matrix_cache__timelimit_s,
-            )
-        # create the dataset location data cache manager:
-        if self.dataset_metadata_cache_manager is None:
-            self.dataset_metadata_cache_manager = CacheManager(
-                max_cached=self.multi_dataset__matrix_cache__max_datasets,
-                timelimit_s=self.multi_dataset__metadata_cache__timelimit_s,
             )
 
     def handle_diffexp(self):

--- a/server/data_common/dataset_metadata.py
+++ b/server/data_common/dataset_metadata.py
@@ -108,38 +108,33 @@ def get_dataset_and_collection_metadata(dataset_explorer_location: str, app_conf
     web_base_url = app_config.server_config.get_web_base_url()
 
     try:
-        dataset_metadata_manager = current_app.dataset_metadata_cache_manager
-        with dataset_metadata_manager.get(
-            cache_key=dataset_explorer_location,
-            create_data_function=get_dataset_metadata_for_explorer_location,
-            create_data_args={"app_config": app_config},
-        ) as base_metadata:
+        base_metadata = get_dataset_metadata_for_explorer_location(dataset_explorer_location, app_config)
 
-            collection_id = base_metadata.get("collection_id")
-            if collection_id is None:
-                return None
+        collection_id = base_metadata.get("collection_id")
+        if collection_id is None:
+            return None
 
-            dataset_id = base_metadata["dataset_id"]
-            collection_visibility = base_metadata["collection_visibility"]
+        dataset_id = base_metadata["dataset_id"]
+        collection_visibility = base_metadata["collection_visibility"]
 
-            suffix = "?visibility=PRIVATE" if collection_visibility == "PRIVATE" else ""
-            suffix_for_url = "/private" if collection_visibility == "PRIVATE" else ""
+        suffix = "?visibility=PRIVATE" if collection_visibility == "PRIVATE" else ""
+        suffix_for_url = "/private" if collection_visibility == "PRIVATE" else ""
 
-            res = requests.get(f"{data_locator_base_url}/collections/{collection_id}{suffix}").json()
+        res = requests.get(f"{data_locator_base_url}/collections/{collection_id}{suffix}").json()
 
-            metadata = {
-                "dataset_name": [dataset["name"] for dataset in res["datasets"] if dataset["id"] == dataset_id][0],
-                "dataset_id": dataset_id,
-                "collection_url": f"{web_base_url}/collections/{collection_id}{suffix_for_url}",
-                "collection_name": res["name"],
-                "collection_description": res["description"],
-                "collection_contact_email": res["contact_email"],
-                "collection_contact_name": res["contact_name"],
-                "collection_links": res["links"],
-                "collection_datasets": res["datasets"],
-            }
+        metadata = {
+            "dataset_name": [dataset["name"] for dataset in res["datasets"] if dataset["id"] == dataset_id][0],
+            "dataset_id": dataset_id,
+            "collection_url": f"{web_base_url}/collections/{collection_id}{suffix_for_url}",
+            "collection_name": res["name"],
+            "collection_description": res["description"],
+            "collection_contact_email": res["contact_email"],
+            "collection_contact_name": res["contact_name"],
+            "collection_links": res["links"],
+            "collection_datasets": res["datasets"],
+        }
 
-            return metadata
+        return metadata
 
     except Exception:
         raise DatasetMetadataError("Error retrieving dataset metadata")

--- a/server/default_config.py
+++ b/server/default_config.py
@@ -85,15 +85,6 @@ server:
       # If timelimit_s is set to None, then there is no time limit.
       timelimit_s: 30
 
-    metadata_cache:
-      # The maximum number of datasets that may be opened at one time.  The least recently used dataset
-      # is evicted from the cache first.
-      max_datasets: 10000
-
-      # A matrix is automatically removed from the cache after timelimit_s number of seconds.
-      # If timelimit_s is set to None, then there is no time limit.
-      timelimit_s: 300
-
   single_dataset:
     # If datapath is set, then cellxgene with serve a single dataset located at datapath.  This parameter is not
     # compatible with multi_dataset/dataroot.

--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -8,5 +8,5 @@ pytest>=3.6.3
 python-jose>=3.2.0
 twine>=1.12.1
 -r requirements.txt
--r requirements-prepare.txt
+#-r requirements-prepare.txt
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,6 @@ pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pand
 PyYAML>=5.4  # CVE-2020-14343
 scipy>=1.4
 requests>=2.22.0
-tiledb==0.10.1
+tiledb==0.10.4
 s3fs==0.4.2
 sqlalchemy>=1.3.18

--- a/server/tests/fixtures/czi_hosted_server_config_outline.py
+++ b/server/tests/fixtures/czi_hosted_server_config_outline.py
@@ -20,9 +20,6 @@ f"""server:
     matrix_cache:
       max_datasets: {max_cached_datasets}
       timelimit_s: {timelimit_s}
-    metadata_cache:
-      max_datasets: {max_cached_dataset_metadata}
-      timelimit_s: {timelimit_s_metadata}
 
   single_dataset:
     datapath: {dataset_datapath}


### PR DESCRIPTION
The cached data can become stale when datasets are revised/tombstoned. The caching of dataset s3 url "lookup" result will not be needed as the s3 url will be directly provided in requests in api v0.3.

#### Reviewers
**Functional:** 
@Bento007 

**Readability:** 
@danieljhegeman 

---

## Changes
Remove all mention of the dataset metadata cache manager.
