### PR TITLE
feat: client uses v0.3 api

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -39,7 +39,7 @@
       window.CELLXGENE = {};
       window.CELLXGENE.API = {
         prefix: `http://localhost:<%= CXG_SERVER_PORT %>${location.pathname}/api/`,
-        version: "v0.2/",
+        version: "v0.3/",
       };
     </script>
     <noscript

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -45,7 +45,7 @@
       window.CELLXGENE = {};
       window.CELLXGENE.API = {
         prefix: `${location.origin}${location.pathname}api/`,
-        version: "v0.2/",
+        version: "v0.3/",
       };
     </script>
     <noscript

--- a/client/src/actions/annotation.ts
+++ b/client/src/actions/annotation.ts
@@ -476,9 +476,14 @@ export const saveGenesetsAction =
         }),
       ]);
     } catch (error) {
+      if (error instanceof Error)
+        return dispatch({
+          type: "autosave: genesets error",
+          message: error.toString(),
+          error,
+        });
       return dispatch({
         type: "autosave: genesets error",
-        message: (error as Error).toString(),
         error,
       });
     }

--- a/client/src/actions/annotation.ts
+++ b/client/src/actions/annotation.ts
@@ -320,6 +320,7 @@ export const needToSaveObsAnnotations = (
 export const saveObsAnnotationsAction =
   () =>
   async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
+    if (!globals.API) throw new Error("API not set");
     const state = getState();
     const { annotations, autosave } = state;
     const { dataCollectionNameIsReadOnly, dataCollectionName } = annotations;
@@ -377,17 +378,19 @@ export const saveObsAnnotationsAction =
         });
       }
     } catch (error) {
-      dispatch({
-        type: "writable obs annotations - save error",
-        message: error.toString(),
-        error,
-      });
+      if (error instanceof Error)
+        dispatch({
+          type: "writable obs annotations - save error",
+          message: error.toString(),
+          error,
+        });
     }
   };
 
 export const saveGenesetsAction =
   () =>
   async (dispatch: AppDispatch, getState: GetState): Promise<unknown> => {
+    if (!globals.API) throw new Error("API not set");
     const state = getState();
 
     // bail if gene sets not available, or in readonly mode.
@@ -475,7 +478,7 @@ export const saveGenesetsAction =
     } catch (error) {
       return dispatch({
         type: "autosave: genesets error",
-        message: error.toString(),
+        message: (error as Error).toString(),
         error,
       });
     }

--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -16,7 +16,7 @@ import * as genesetActions from "./geneset";
 import { AppDispatch, GetState } from "../reducers";
 import { EmbeddingSchema, Schema } from "../common/types/schema";
 import { ConvertedUserColors } from "../reducers/colors";
-import { DatasetMetadata, Dataset } from "../common/types/entities";
+import type { DatasetMetadata, Dataset, S3URI } from "../common/types/entities";
 import { postExplainNewTab } from "../components/framework/toasters";
 import { KEYS } from "../components/util/localStorage";
 import {
@@ -50,6 +50,10 @@ async function userColorsFetchAndLoad(
       userColors: loadUserColorConfig(response),
     })
   );
+}
+
+async function s3URIFetch(): Promise<{ s3_uri: S3URI }> {
+  return fetchJson<{ s3_uri: S3URI }>("s3_uri");
 }
 
 async function schemaFetch(): Promise<{ schema: Schema }> {
@@ -145,6 +149,8 @@ const doInitialDataLoad = (): ((
     dispatch({ type: "initial data load start" });
 
     try {
+      const { s3_uri: s3URI } = await s3URIFetch();
+      globals.updateAPIWithS3(s3URI);
       const [config, schema] = await Promise.all([
         configFetch(dispatch),
         schemaFetch(),

--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -52,8 +52,8 @@ async function userColorsFetchAndLoad(
   );
 }
 
-async function s3URIFetch(): Promise<{ s3_uri: S3URI }> {
-  return fetchJson<{ s3_uri: S3URI }>("s3_uri");
+async function s3URIFetch(): Promise<S3URI> {
+  return fetchJson<S3URI>("s3_uri");
 }
 
 async function schemaFetch(): Promise<{ schema: Schema }> {
@@ -149,7 +149,8 @@ const doInitialDataLoad = (): ((
     dispatch({ type: "initial data load start" });
 
     try {
-      const { s3_uri: s3URI } = await s3URIFetch();
+      const s3URI = await s3URIFetch();
+      console.log("s3_uri", s3URI);
       globals.updateAPIWithS3(s3URI);
       const [config, schema] = await Promise.all([
         configFetch(dispatch),

--- a/client/src/common/types/entities.ts
+++ b/client/src/common/types/entities.ts
@@ -37,7 +37,10 @@ export interface DatasetMetadata {
   collection_url: string;
   dataset_id: string;
   dataset_name: string;
+  s3_URI: S3URI;
 }
+
+export type S3URI = string;
 
 /**
  * Corpora encoding and schema versioning.

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -179,7 +179,8 @@ export function updateApiPrefix(): void {
 }
 
 export function updateAPIWithS3(s3URI: S3URI): void {
-  const URISafeS3URI = encodeURI(s3URI);
-  const flaskSafeS3URI = encodeURI(URISafeS3URI);
+  const URISafeS3URI = encodeURIComponent(s3URI);
+  console.log(URISafeS3URI);
+  const flaskSafeS3URI = `${encodeURIComponent(URISafeS3URI)}/`;
   API.prefix = API.prefix.replace(REGEX_PATHNAME, flaskSafeS3URI);
 }

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -1,7 +1,7 @@
 import { Colors } from "@blueprintjs/core";
 import { dispatchNetworkErrorMessageToUser } from "./util/actionHelpers";
 import ENV_DEFAULT from "../../environment.default.json";
-import { DataPortalProps } from "./common/types/entities";
+import { DataPortalProps, S3URI } from "./common/types/entities";
 
 /* overflow category values are created  using this string */
 export const overflowCategoryLabel = ": all other labels";
@@ -156,10 +156,10 @@ if ((window as any).CELLXGENE && (window as any).CELLXGENE.API) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   _API = (window as any).CELLXGENE.API;
 } else if (CXG_SERVER_PORT === undefined) {
-    const errorMessage = "Please set the CXG_SERVER_PORT environment variable.";
-    dispatchNetworkErrorMessageToUser(errorMessage);
-    throw new Error(errorMessage);
-  }
+  const errorMessage = "Please set the CXG_SERVER_PORT environment variable.";
+  dispatchNetworkErrorMessageToUser(errorMessage);
+  throw new Error(errorMessage);
+}
 
 export const API = _API;
 
@@ -176,4 +176,10 @@ export function updateApiPrefix(): void {
   // For the API prefix in the format protocol/host/pathSegement/e/uuid.cxg, replace /e/uuid.cxg with the corresponding
   // path segments taken from the pathname.
   API.prefix = API.prefix.replace(REGEX_PATHNAME, pathname);
+}
+
+export function updateAPIWithS3(s3URI: S3URI): void {
+  const URISafeS3URI = encodeURI(s3URI);
+  const flaskSafeS3URI = encodeURI(URISafeS3URI);
+  API.prefix = API.prefix.replace(REGEX_PATHNAME, flaskSafeS3URI);
 }

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -39,6 +39,7 @@ export interface Config {
     "disable-diffexp"?: boolean;
     "diffexp-may-be-slow"?: boolean;
     default_embedding?: string;
+    "max-category-items"?: number;
     [key: string]: unknown;
   };
   portalUrl: string;


### PR DESCRIPTION
#### Reviewers
**Functional:** @tihuan 

**Readability:** @Bento007, @MillenniumFalconMechanic 

---

## Changes
- add
   - `s3URIFetch`
   - `updateAPIWithS3()` swaps out preloaded API embedded in HTML with S3URI prefix
- remove
- modify
   - Modify templates to use `v0.3`
   - Changed naming of some endpoint request helper functions to better reflect fetch vs fetchAndLoad
   - Various typing and type safety
