### PR TITLE
revert tiledb ver to 0.10.1

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,6 @@ pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pand
 PyYAML>=5.4  # CVE-2020-14343
 scipy>=1.4
 requests>=2.22.0
-tiledb==0.10.4
+tiledb==0.10.1
 s3fs==0.4.2
 sqlalchemy>=1.3.18


### PR DESCRIPTION

#### Reviewers
**Functional:** 
any sc-eng

**Readability:** 
any sc-eng

---

## Changes
tiledb version 0.10.4 update was erroneously committed for local dev purposes, and does not agree with the single-cell-infra requirements.txt, causing deploy failure.  Could update in single-cell-infra, but better to upgrade tiledb more deliberately; in particular, tiledb 0.11.x is available now.

