### PR TITLE
fix: remove trailing slash from s3_uri

### DIFF
--- a/server/app/api/util.py
+++ b/server/app/api/util.py
@@ -5,7 +5,8 @@ from server.data_common.matrix_loader import MatrixDataLoader
 
 
 def get_dataset_artifact_s3_uri(url_dataroot: str = None, dataset_id: str = None):
-    dataset_artifact_s3_uri = get_dataset_metadata(url_dataroot, dataset_id, current_app.app_config)["s3_uri"].rstrip('/')
+    dataset_artifact_s3_uri = get_dataset_metadata(url_dataroot, dataset_id, current_app.app_config)["s3_uri"]
+    dataset_artifact_s3_uri = dataset_artifact_s3_uri.rstrip("/")  # remove trailing slash for cloudfront caching.
     return dataset_artifact_s3_uri
 
 

--- a/server/app/api/util.py
+++ b/server/app/api/util.py
@@ -5,7 +5,7 @@ from server.data_common.matrix_loader import MatrixDataLoader
 
 
 def get_dataset_artifact_s3_uri(url_dataroot: str = None, dataset_id: str = None):
-    dataset_artifact_s3_uri = get_dataset_metadata(url_dataroot, dataset_id, current_app.app_config)["s3_uri"]
+    dataset_artifact_s3_uri = get_dataset_metadata(url_dataroot, dataset_id, current_app.app_config)["s3_uri"].rstrip('/')
     return dataset_artifact_s3_uri
 
 

--- a/server/tests/unit/common/apis/test_api_v3.py
+++ b/server/tests/unit/common/apis/test_api_v3.py
@@ -748,6 +748,24 @@ class TestS3URI(BaseTest):
         self.assertEqual(json.loads(result.data), s3_uri)
 
     @patch("server.data_common.dataset_metadata.requests.get")
+    def test_get_S3_URI_in_data_portal_format(self, mock_get):
+        s3_uri = f"{FIXTURES_ROOT}/pbmc3k.cxg/"
+        response_body = json.dumps(
+            {
+                "collection_id": "4f098ff4-4a12-446b-a841-91ba3d8e3fa6",
+                "collection_visibility": "PUBLIC",
+                "dataset_id": "2fa37b10-ab4d-49c9-97a8-b4b3d80bf939",
+                "s3_uri": s3_uri,
+                "tombstoned": False,
+            }
+        )
+        mock_get.return_value = MockResponse(body=response_body, status_code=200)
+
+        result = self.client.get(self.url)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+        self.assertEqual(json.loads(result.data), s3_uri[:-1])
+
+    @patch("server.data_common.dataset_metadata.requests.get")
     def test_get_S3_URI_not_in_data_portal(self, mock_get):
         mock_get.return_value = MockResponse(body="", status_code=404)
         result = self.client.get(self.url)


### PR DESCRIPTION
#### Reviewers
**Functional:**  @atolopko-czi 

**Readability:** @seve 

---

Remove trailing slash from the s3_uri that is used in the `/s3_uri/<s3_uri>/api/v0.3` requests, to ensure that all requests are properly utilizing the CloudFront cache. This woull change this:

`/cellxgene/s3_uri/s3%253A%252F%252Fhosted-cellxgene-dev%252Fpbmc3k.cxg%252F/api/v0.3/genesets`

to this

`/cellxgene/s3_uri/s3%253A%252F%252Fhosted-cellxgene-dev%252Fpbmc3k.cxg/api/v0.3/genesets`



## Changes
- remove the trailing slash from S3_URIs before returning in GET */s3_uri
