### PR TITLE
fix: tombstoned datatset index page redirect

### DIFF
--- a/server/app/api/__init__.py
+++ b/server/app/api/__init__.py
@@ -22,7 +22,7 @@ def _cache_control(always, **cache_kwargs):
             if response.status_code >= 400:
                 return response
             for k, v in cache_kwargs.items():
-                setattr(cache_control, k, v)
+                setattr(response.cache_control, k, v)
             return response
 
         return wrapper


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@Bento007 

**Readability:** 

---

## Changes
The cache control headers were no longer being applied to a coding error introduced during refactoring. This was causing the dataset index endpoint to be cached by CloudFront, which meant that changes to the tombstone status were not being handled by the backend.  It also means that all other endpoints that specified the `@cache_control` annotation were not having cache control headers applied.

## Testing
Verified that https://rdev-164-caching-redesign-explorer.rdev.single-cell.czi.technology/e/d0e594f3-26b8-4598-810f-4054760e0d45.cxg/  responds with `cache-control: no-store` header. Cannot the full tombstoning flow in rdev, since CloudFront is not configured on rdev. Will need to do final test in dev env.