### PR TITLE
fix rdev non-GHA builds

### DIFF
--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -47,4 +47,4 @@ jobs:
           DOCKER_TAG=${DOCKER_TAG#refs/tags/}
           # replace `/` with `_`
           DOCKER_TAG=${DOCKER_TAG//\//-}
-          scripts/happy --profile="" push --extra-tag ${DOCKER_TAG} --extra-tag sha-${GITHUB_SHA:0:8} --extra-tag build-${GITHUB_RUN_NUMBER} ${{ matrix.component }}
+          scripts/happy --profile="" push --stack-name ${DOCKER_TAG} --extra-tag sha-${GITHUB_SHA:0:8} --extra-tag build-${GITHUB_RUN_NUMBER} ${{ matrix.component }}

--- a/scripts/happy
+++ b/scripts/happy
@@ -1169,7 +1169,6 @@ def push(ctx, images, tag, extra_tag, compose_env, stack_name):
     # container at run time.  (Note that images built on localhost via the `single-cell-infra/scripts/happy` script set
     # this similarly.)
     if stack_name:
-        # HACK: Set the happy env name at ,
         print(f"Setting happy_env (rdev stack name) to {stack_name}")
         builder_config["happy_env"] = stack_name
 

--- a/scripts/happy
+++ b/scripts/happy
@@ -1136,8 +1136,12 @@ def login_ecrs(images, ecrs, ecr_client):
 )
 @click.option("--extra-tag", help="Extra tags to apply and push to the docker repo.", multiple=True)
 @click.option("--compose-env", help="Environment file to pass to docker compose", default=None)
+@click.option("--stack-name",
+              help="The rdev stack name to set in the env of the built image. " 
+                   "Only needed when being called by the push-rdev GHA.",
+              default=None)
 @click.pass_context
-def push(ctx, images, tag, extra_tag, compose_env):
+def push(ctx, images, tag, extra_tag, compose_env, stack_name):
     """Build and push docker images to ECR. Optionally filter by service name"""
     config = ctx.obj["config"]
     ecrs = config.ecrs
@@ -1160,19 +1164,22 @@ def push(ctx, images, tag, extra_tag, compose_env):
     # images to the right places with some re-tagging.
     first_registry = get_ecr_repo(config)
     builder_config["ecr_repo"] = first_registry  # TODO this is a leak in our abstraction, need to fix.
-    # HACK: Sets happy env name to the first extra tag; we need to know the happy env name at docker image build time, unfortunately, since it's not parameterized in the Docker image env
-    rdev_stack_name = extra_tag[0]
-    print(f"Setting happy_env (rdev stack name) to {rdev_stack_name}")
-    builder_config["happy_env"] = rdev_stack_name
+    # Stack name needs to be set in docker image at build time when this build is being triggered by the push-rdev GHA.
+    # Unfortunately, the stack name is not parameterized in the Docker image env and therefore cannot be set in
+    # container at run time.  (Note that images built on localhost via the `single-cell-infra/scripts/happy` script set
+    # this similarly.)
+    if stack_name:
+        # HACK: Set the happy env name at ,
+        print(f"Setting happy_env (rdev stack name) to {stack_name}")
+        builder_config["happy_env"] = stack_name
 
     builder = ArtifactBuilder(builder_config)
     artifacts = builder.build(images)
     print("Build complete")
 
-    # extra_tag is a tuple
-    all_tags = [tag] + (list(extra_tag) or [])
     print("Pushing images...")
-    all_tags = [tag] + (list(extra_tag) or [])
+    # extra_tag is a tuple
+    all_tags = [tag] + (list(extra_tag) or []) + ([stack_name] if stack_name else [])
     builder.push(ecrs, artifacts, all_tags)
     print(f"Built and pushed docker images with tags: {all_tags}")
 


### PR DESCRIPTION
### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
Add explicit --stack-name option for GHA-based builds of docker images. Replaces the use of --extra-tag to pass in the stack name. This allows the script to work in non-GHA build usages.

## Definition of Done (from ticket)

## QA steps (optional)

Tested:
* single-cell-infra happy explorer + data portal rdev *local* create
* single-cell-infra happy explorer + data portal rdev *GHA* create
* single-cell-data-portal happy *local* create

## Known Issues
