### PR TITLE
chore: pin black version to avoid breaking compatibility with click 8

### DIFF
--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 Authlib>=0.14.3
-black
+black==21.12b0
 bumpversion>=0.5
 codecov>=2.0.15
 parameterized>=0.7.0


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@seve @atolopko-czi 

**Readability:** 

---

## Changes
- The newest version of Black requires click 8.0.0 which isn't compatible with our other requirements. 