### PR TITLE
feat: add publisher_metadata to the dataset metadata endpoint

### DIFF
--- a/server/dataset/dataset_metadata.py
+++ b/server/dataset/dataset_metadata.py
@@ -138,6 +138,9 @@ def get_dataset_and_collection_metadata(dataset_root: str, dataset_id: str, app_
             "collection_datasets": res["datasets"],
         }
 
+        if res.get("publisher_metadata"):
+            metadata["collection_publisher_metadata"] = res["publisher_metadata"]
+
         return metadata
 
     except Exception as ex:

--- a/server/tests/unit/common/apis/test_api_v2.py
+++ b/server/tests/unit/common/apis/test_api_v2.py
@@ -658,6 +658,9 @@ class TestDatasetMetadata(BaseTest):
                 "http://test.link",
             ],
             "name": "Test Collection",
+            "publisher_metadata": {
+                "journal": "Nature",
+            },
             "visibility": "PUBLIC",
         }
 
@@ -685,6 +688,7 @@ class TestDatasetMetadata(BaseTest):
         self.assertEqual(response_obj["collection_description"], response_body["description"])
         self.assertEqual(response_obj["collection_links"], response_body["links"])
         self.assertEqual(response_obj["collection_datasets"], response_body["datasets"])
+        self.assertDictEqual(response_obj["collection_publisher_metadata"], response_body["publisher_metadata"])
 
     @patch("server.dataset.dataset_metadata.request_dataset_metadata_from_data_portal")
     @patch("server.dataset.dataset_metadata.requests.get")


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@atolopko-czi @MDunitz 

**Readability:** 

---

## Changes
- Adds the `publisher_metadata` field to the dataset metadata endpoint call.
