### PR TITLE
Update breaking jinja dependency

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -20,3 +20,4 @@ scipy>=1.4
 requests>=2.22.0
 tiledb==0.10.4
 s3fs==0.4.2
+MarkupSafe==1.1.1


### PR DESCRIPTION
Resolves #230 
The latest version of MarkupSafe (used by jinja) introduced a breaking change so we need to pin to an older version.
Longer term we should strongly consider fully pinning our dependencies