### PR TITLE
chore: replaced deprecated method to open TileDB array (#56)

### DIFF
--- a/server/dataset/cxg_dataset.py
+++ b/server/dataset/cxg_dataset.py
@@ -187,7 +187,7 @@ class CxgDataset(Dataset):
 
     @staticmethod
     def _open_array(uri, tiledb_ctx):
-        with tiledb.Array(uri, mode="r", ctx=tiledb_ctx) as array:
+        with tiledb.open(uri, mode="r", ctx=tiledb_ctx) as array:
             if array.schema.sparse:
                 return tiledb.SparseArray(uri, mode="r", ctx=tiledb_ctx)
             else:

--- a/server/dataset/cxg_dataset.py
+++ b/server/dataset/cxg_dataset.py
@@ -187,11 +187,7 @@ class CxgDataset(Dataset):
 
     @staticmethod
     def _open_array(uri, tiledb_ctx):
-        with tiledb.open(uri, mode="r", ctx=tiledb_ctx) as array:
-            if array.schema.sparse:
-                return tiledb.SparseArray(uri, mode="r", ctx=tiledb_ctx)
-            else:
-                return tiledb.DenseArray(uri, mode="r", ctx=tiledb_ctx)
+        return tiledb.open(uri, mode="r", ctx=tiledb_ctx)
 
     def open_array(self, name):
         try:


### PR DESCRIPTION
#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- modify: replaced deprecated `tiledb.Array()` with `tiledb.open()`
