### PR TITLE
bump tiledb to 0.13.1, add work-around for dense read bug

### DIFF
--- a/hosted/requirements.txt
+++ b/hosted/requirements.txt
@@ -46,7 +46,7 @@ umap-learn==0.4.6
 sentry-sdk[flask]==0.14.3
 six==1.14.0
 sqlalchemy==1.3.18
-tiledb==0.10.1
+tiledb==0.13.1
 urllib3==1.26.5
 Werkzeug==1.0.1
 zipp==3.1.0

--- a/server/dataset/cxg_dataset.py
+++ b/server/dataset/cxg_dataset.py
@@ -57,7 +57,7 @@ class CxgDataset(Dataset):
             for use of the legacy reader, which works correctly. It can be removed when the
             test case `test_tdb_bug` in server/tests/unit/dataest/test_cxg_dataset.py passes
             """
-            context_params |= {"sm.query.dense.reader": "legacy"}
+            context_params["sm.query.dense.reader"] = "legacy"
 
             CxgDataset.tiledb_ctx = tiledb.Ctx(context_params)
             tiledb.default_ctx(context_params)

--- a/server/dataset/cxg_dataset.py
+++ b/server/dataset/cxg_dataset.py
@@ -52,6 +52,13 @@ class CxgDataset(Dataset):
     def set_tiledb_context(context_params):
         """Set the tiledb context.  This should be set before any instances of CxgDataset are created"""
         try:
+            """
+            TileDB 0.13.1 has a bug in the new dense reader. This config (workaround) will
+            for use of the legacy reader, which works correctly. It can be removed when the
+            test case `test_tdb_bug` in server/tests/unit/dataest/test_cxg_dataset.py passes
+            """
+            context_params |= {"sm.query.dense.reader": "legacy"}
+
             CxgDataset.tiledb_ctx = tiledb.Ctx(context_params)
             tiledb.default_ctx(context_params)
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,6 @@ pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pand
 PyYAML>=5.4  # CVE-2020-14343
 scipy>=1.4
 requests>=2.22.0
-tiledb==0.10.4
+tiledb==0.13.1
 s3fs==0.4.2
 MarkupSafe==1.1.1

--- a/server/tests/unit/dataset/test_cxg_dataset.py
+++ b/server/tests/unit/dataset/test_cxg_dataset.py
@@ -1,10 +1,16 @@
 import unittest
 
+from werkzeug.datastructures import MultiDict
+
+from server.common.rest import _query_parameter_to_filter
 from server.common.utils.data_locator import DataLocator
 from server.dataset.cxg_dataset import CxgDataset
 from server.tests.unit import app_config
-from server.tests import FIXTURES_ROOT
+from server.tests import FIXTURES_ROOT, decode_fbs
 from server.tests.fixtures.fixtures import pbmc3k_colors
+
+import tiledb
+import numpy as np
 
 
 class TestCxgDataset(unittest.TestCase):
@@ -18,3 +24,27 @@ class TestCxgDataset(unittest.TestCase):
         data_locator = f"{FIXTURES_ROOT}/{fixture}"
         config = app_config(data_locator)
         return CxgDataset(DataLocator(data_locator), config)
+
+    def test_tdb_bug(self):
+        """
+        This gives different results on 0.12.4 vs 0.13.1. Reported to TileDB.
+        Work-around present in server/dataset/cxg_dataset.py:set_tiledb_context()
+        """
+        print(tiledb.__version__)
+        data = self.get_data("pbmc3k.cxg")
+        filt = _query_parameter_to_filter(
+            MultiDict(
+                [
+                    ("var:name_0", "F5"),
+                    ("var:name_0", "BEB3"),
+                    ("var:name_0", "SIK1"),
+                ]
+            )
+        )
+        dat = data.summarize_var("mean", filt, 0)
+        summary = decode_fbs.decode_matrix_FBS(dat)
+        self.assertDictContainsSubset({"n_rows": 2638, "n_cols": 1, "row_idx": None}, summary)
+        self.assertIs(type(summary["columns"]), list)
+        self.assertEqual(len(summary["columns"]), 1)
+        self.assertEqual(len(summary["columns"][0]), 2638)
+        self.assertEqual(summary["columns"][0].sum(), np.float32(-19.00301))


### PR DESCRIPTION
Bump tiledb dependency to 0.13.1, and add _temporary_ work-around for dense array read bug.  Add test case to verify the work-around resolves the issue.

#### Reviewers
**Functional:** @metakuni @atolopko-czi 

**Readability:** 

---

## Changes
- add tiledb==0.13.1 to requirements files.
- add test case (modified version of test case from Ben, borrowed from #234)
