### PR TITLE
fix: Docker-compose specify platform to get around arm vs amd arch mismatches

### DIFF
--- a/.happy/config.json
+++ b/.happy/config.json
@@ -4,6 +4,7 @@
     "default_env": "rdev",
     "app": "hosted-cellxgene",
     "default_compose_env_file": ".env.ecr",
+    "default_compose_env": ".env.ecr",
     "environments": {
         "rdev": {
             "aws_profile": "single-cell-dev",

--- a/.happy/config.json
+++ b/.happy/config.json
@@ -3,7 +3,7 @@
     "terraform_version": "0.13.5",
     "default_env": "rdev",
     "app": "hosted-cellxgene",
-    "default_compose_env": ".env.ecr",
+    "default_compose_env_file": ".env.ecr",
     "environments": {
         "rdev": {
             "aws_profile": "single-cell-dev",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
 
   localstack:
     image: localstack/localstack@sha256:7c6635493185d25165979995fb073fd789c72b6d8b17ef3a70b798d55576732f
-    platform: linux/amd64
     ports:
       - "4566:4566"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
 
   localstack:
     image: localstack/localstack@sha256:7c6635493185d25165979995fb073fd789c72b6d8b17ef3a70b798d55576732f
+    platform: linux/amd64
     ports:
       - "4566:4566"
     environment:
@@ -17,12 +18,13 @@ services:
     volumes:
       - localstack:/tmp/localstack
     networks:
-       corporanet:
-          aliases:
-            - localstack.corporanet.local
+      corporanet:
+        aliases:
+          - localstack.corporanet.local
 
   explorer:
     image: "${DOCKER_REPO}corpora-explorer"
+    platform: linux/amd64
     build:
       context: .
       dockerfile: hosted/Dockerfile
@@ -57,9 +59,9 @@ services:
       # SecretsManager population relies on oauth json
       - ./oauth/users.json:/oauth/users.json
     networks:
-       corporanet:
-          aliases:
-            - backend.corporanet.local
+      corporanet:
+        aliases:
+          - backend.corporanet.local
 networks:
   corporanet:
 volumes:


### PR DESCRIPTION
Make sure we build/run x86 images everywhere.
See https://github.com/chanzuckerberg/czgenepi/pull/999/files 

#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- add
- remove
- modify
