### PR TITLE
bump tiledb ver, to stay on par with portal (tiledb writer)

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,6 @@ pandas>=1.0,!=1.1  # pandas 1.1 breaks tests, https://github.com/pandas-dev/pand
 PyYAML>=5.4  # CVE-2020-14343
 scipy>=1.4
 requests>=2.22.0
-tiledb==0.13.1
+tiledb==0.13.2  # Explorer's major/minor tiledb version should always be the >= Portal's tiledb major/minor version (for read/write compatibility)
 s3fs==0.4.2
 MarkupSafe==1.1.1


### PR DESCRIPTION
In reaction to [this Portal update](https://github.com/chanzuckerberg/single-cell-data-portal/pull/2214/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R26)