### PR TITLE
chore: Clean up development guidelines.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ CLEANFILES :=  $(BUILDDIR)/ client/build build dist cellxgene.egg-info
 
 PART ?= patch
 
-# CLEANING
+# CLEANING COMMANDS
+
 .PHONY: clean
 clean: clean-lite clean-server clean-client
 
@@ -24,7 +25,7 @@ clean-client:
 clean-server:
 	cd server && $(MAKE) clean
 
-# BUILDING PACKAGE
+# BUILDING PACKAGE COMMANDS
 
 .PHONY: build-client
 build-client:
@@ -68,7 +69,7 @@ smoke-test:
 smoke-test-annotations:
 	cd client && $(MAKE) smoke-test-annotations
 
-# FORMATTING CODE
+# LINTING AND FORMATTING COMMANDS
 
 .PHONY: fmt
 fmt: fmt-client fmt-server
@@ -92,6 +93,7 @@ lint-server:
 lint-client:
 	cd client && $(MAKE) lint
 
+# DEPENDENCY PACKAGE INSTALLATION COMMANDS
 
 .PHONY: dev-env
 dev-env: dev-env-client dev-env-server

--- a/dev_docs/developer_guidelines.md
+++ b/dev_docs/developer_guidelines.md
@@ -23,7 +23,7 @@ You can set these environment variables manually with the `export` shell command
 
 1. Run `make build-for-server-dev`. This will build the client and put static files in place.
 1. Run `./launch_dev_server.sh [dataset] [options]`. This will launch at server at http://localhost:5005.
-   1. Note: you will need to ensure that the dataset format is in CXG. A small dataset is included in this repository [here](https://github.com/chanzuckerberg/single-cell-explorer/tree/main/example-dataset/pbmc3k.cxg). To use this dataset, you would run `./launch_dev_server.sh example-dataset/ [options]`. Note that the `pbmc3k.cxg` is purposefully missing because the command expects a directory of datasets.
+   1. Note: you will need to ensure that the dataset format is in CXG. A small dataset is included in this repository [here](https://github.com/chanzuckerberg/single-cell-explorer/tree/main/example-dataset/pbmc3k.cxg). To use this dataset, you would run `./launch_dev_server.sh example-dataset/ [options]`. Note that the `pbmc3k.cxg` is not specified in the command because the program expects a directory of datasets.
 1. You may navigate to http://localhost:5005/d/{dataset_name} to view the dataset. Note that there will not be hot-loading for the frontend if you make changes to the client.
 
 If you make changes to the server, you will need to restart the server in order for the changes to take.

--- a/dev_docs/developer_guidelines.md
+++ b/dev_docs/developer_guidelines.md
@@ -14,29 +14,62 @@ For all `make` commands, `common.mk` automatically checks whether required envir
 
 You can set these environment variables manually with the `export` shell command, as in `export JEST_ENV=debug`, or you can just pass the variables as part of the command. E.g., `HEADFUL=true make e2e` or `JEST_ENV=debug npm run e2e`
 
-## Running test suite
+## Start developing locally
 
-Client and server tests run on Travis CI for every push, PR, and commit to `main` on github. End to end tests run nightly on `main` only.
+1. Ensure that you have a [Python virtual environment](https://docs.python.org/3/library/venv.html) set up and activated (`source venv/bin/activate`).
+1. Run `make dev-env` to install the appropriate dependencies for both the frontend and backend.
 
-### Unit tests
+### If you are only developing for the server...
 
-Steps to run the all unit tests:
+1. Run `make build-for-server-dev`. This will build the client and put static files in place.
+1. Run `./launch_dev_server.sh [dataset] [options]`. This will launch at server at http://localhost:5005.
+   1. Note: you will need to ensure that the dataset format is in CXG. A small dataset is included in this repository [here](https://github.com/chanzuckerberg/single-cell-explorer/tree/main/example-dataset/pbmc3k.cxg). To use this dataset, you would run `./launch_dev_server.sh example-dataset/ [options]`. Note that the `pbmc3k.cxg` is purposefully missing because the command expects a directory of datasets.
+1. You may navigate to http://localhost:5005/d/{dataset_name} to view the dataset. Note that there will not be hot-loading for the frontend if you make changes to the client.
+
+If you make changes to the server, you will need to restart the server in order for the changes to take.
+
+### If you are also developing for the frontend...
+
+To launch with hot reloading, you need to launch the server and the client separately. Node's hot reloading starts the client on its own node server and auto-refreshes when changes are made to source files.
+
+1. First, ensure that you have a server running.
+1. Run `cd client/` and then `make start-frontend`.
+1. Navigate to `localhost:3000/d/<dataset>` in your web browser. This is where your client will be served.
+   - Default base_url of `d` is hard-coded.
+   - The `dataset` will be the argument passed to the server launch script OR will default to example dataset.
+   - The entire url is automatically copied to the clipboard on MacOS -- simply paste in browser address bar.
+
+Note: in case you need to just build the client alone, you can run `make build-client`.
+
+### Before you request a PR review...
+
+Please lint and format your code before requesting a PR review. 
+
+We use [`flake8`](https://github.com/PyCQA/flake8) to lint Python and [`black`](https://pypi.org/project/black/) for auto-formatting Python. The frontend Javascript/Typescript code is linted by `eslint` and formatted by `prettier`.
+
+1. Format your code by running `make fmt`. Note that this command will make changes to your files that you will need to commit to your branch.
+1. Lint your code by running `make lint`. This command will only emit errors and warnings and will not make changes to your files. You will have to manually address the issues.
+
+## How to run tests
+
+Client and server tests run on [Github Actions](https://github.com/chanzuckerberg/single-cell-explorer/actions/workflows/push_tests.yml) for every push, PR, and commit to `main` on Github. Smoke tests are run upon every dev deployment which occurs automatically every time a PR merged into `main`.
+
+### Pre-requisites
 
 1. Start in the project root directory
-1. `make dev-env`
-1. `make unit-test`
+1. Run `make dev-env`
 
-To run unit tests for the `client` code only:
+### Testing Command Cheat Sheet
 
-1. Start in the project root directory
-1. `cd client`
-1. `make unit-test`
+| What are you testing | Command |
+|---|---|
+| I want to run unit tests for the backend only. | `make unit-test-server` |
+| I want to run unit tests for the frontend only. | `make unit-test-client` |
+| I want to run unit and smoke tests for the backend. | `make test-server` |
+| I want to only run smoke tests. | `make smoke-test` |
+| I want to run smoke tests against my hot-loaded verion of the client. | `cd client && npm run e2e` |
 
-### End to end tests
-
-To run E2E tests, run `make smoke-test`
-
-#### Flags
+### Flags
 
 1. `JEST_ENV`: This enables the following E2E test options. You can find their corresponding configs in [`jest-puppeteer.config.js`](../client/jest-puppeteer.config.js):
 
@@ -44,100 +77,24 @@ To run E2E tests, run `make smoke-test`
    - `debug` - opens window, runs tests with 100ms slowdown, dev tools open, chrome stays open on exit.
    - `prod`[default] - run headless with no slowdown, window will not open.
 
-2. `HEADFUL`: Default is `false`. When set to `true`, it will launch the Chrome window for visual inspection. E.g., `HEADFUL=true npm run e2e`
+1. `HEADFUL`: Default is `false`. When set to `true`, it will launch the Chrome window for visual inspection. E.g., `HEADFUL=true npm run e2e`
 
-3. `HEADLESS`: Default is `true`. When set to `false`, it will launch the Chrome window for visual inspection. E.g., `HEADLESS=false npm run e2e`
+1. `HEADLESS`: Default is `true`. When set to `false`, it will launch the Chrome window for visual inspection. E.g., `HEADLESS=false npm run e2e`
 
-#### Run end to end tests interactively during development
+### Run end to end tests interactively during development
 
-1. The Explorer requirements should be installed as [specified in client dev](#install)
-
-1. Follow [launch](#launch) instructions for client dev (defaults to `example-dataset/pbmc3k.cxg` dataset unless otherwise specified)
-
+1. The Explorer requirements should be installed as [specified in client dev](#Start-developing-locally)
+1. Follow [launch](#If-you-are-also-developing-for-the-frontend...) instructions for client dev (defaults to `example-dataset/pbmc3k.cxg` dataset unless otherwise specified)
 1. Run `npm run e2e` from the `client` directory
-
 1. To debug a failing test, add `debugger` in any line of JS code as breakpoint, and launch the test again with [`ndb`](https://github.com/GoogleChromeLabs/ndb). E.g., `ndb make e2e` or `ndb npm run e2e`.
 
    1. Please make sure to install `ndb` via `npm install -g ndb`
-
    1. Check out [Debugging Tips](e2e_tests.md#debugging-tips) for more ideas!
+
+**See more** on E2E testing [here](e2e_tests.md).
 
 #### To run end to end tests _exactly_ as they will be run on CI use the following command
 
 ```shell
 JEST_ENV=prod make dev-env smoke-test
 ```
-
-## Server dev
-
-### Build
-
-Build the client and put static files in place
-
-```make build-for-server-dev```
-
-### Launch
-
-```./launch_dev_server.sh [dataset] [options]```
-
-### Linter
-
-We use [`flake8`](https://github.com/PyCQA/flake8) to lint python and [`black`](https://pypi.org/project/black/) for auto-formatting.
-
-To auto-format code run `make fmt`. To run lint checks on the code run `make lint`.
-
-### Test
-
-If you would like to run the server tests individually, follow the steps below
-
-1. Install development requirements `make dev-env`
-1. Run `make unit-test` in the `server/` directory or `make unit-test-server` in the root directory.
-
-### Tips
-
-- Install in a virtualenv
-- May need to rebuild/reinstall when you make client changes
-
-## Client dev
-
-### Install
-
-1. Install prereqs for client: `make dev-env`
-
-### Launch
-
-To launch with hot reloading, you need to launch the server and the client separately. Node's hot reloading starts the client on its own node server and auto-refreshes when changes are made to source files.
-
-1. Launch server (the client relies on the REST API being available): `./launch_dev_server.sh [dataset] [options]`
-2. Launch client: in `client/` directory run `make start-frontend`
-3. Client will be served on `localhost:3000/d/<dataset>`
-   - Default base_url of `d` is hard-coded.
-   - The `dataset` will be the argument passed to the server launch script OR will default to example dataset
-   - The entire url is automatically copied to the clipboard on MacOS -- simply paste in browser address bar
-
-### Build
-
-To build only the client: `make build-client`
-
-### Linter
-
-We use `eslint` to lint the code and `prettier` as our code formatter.
-
-### Test
-
-If you would like to run the client tests individually, follow the steps below in the `client` directory
-
-1. For unit tests run `make unit-test`
-1. For the smoke test run `make smoke-test` for the standard smoke test suite and `make smoke-test-annotations` for the annotations test suite.
-
-If you would like to run the smoke tests against a hot-reloaded version of the client:
-
-1. Start the hot-reloading servers as described in the [Client dev section](#client-dev). If you plan to run the standard test suite (without annotations), you'll have to start the backend server with annotations disabled (e.g. `./launch_dev_server.sh --debug --disable-annotations`).
-1. From the project root, `cd client`
-1. Run either the standard E2E test suite with `npm run e2e` or the annotations test suite with `npm run e2e-annotations`
-
-### Tips
-
-- You can also launch the server side code from npm scrips (requires python3.6 with virtualenv) with the `scripts/backend_dev` script.
-
-- Check out [e2e Tests](e2e_tests.md) for more details

--- a/launch_dev_server.sh
+++ b/launch_dev_server.sh
@@ -9,4 +9,3 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 export PYTHONPATH=${PROJECT_ROOT}  # permits module discovery when run from somewhere other than top level dir
 
 PROJECT_ROOT=${PROJECT_ROOT} python -m server.cli.launch $@
-

--- a/launch_dev_server.sh
+++ b/launch_dev_server.sh
@@ -9,3 +9,4 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 export PYTHONPATH=${PROJECT_ROOT}  # permits module discovery when run from somewhere other than top level dir
 
 PROJECT_ROOT=${PROJECT_ROOT} python -m server.cli.launch $@
+

--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -3,6 +3,7 @@ Authlib>=0.14.3
 black==21.12b0
 bumpversion>=0.5
 codecov>=2.0.15
+flake8>=4.0.0
 parameterized>=0.7.0
 psycopg2-binary>=2.8.5
 pytest>=3.6.3


### PR DESCRIPTION
### Reviewers

**Functional:** @ebezzi 

**Readability:** N/A

---

### Changes

#### Additions

- Added flake8 as a dependency in the dev requirements. Without this, the linter commands were failing.

#### Modifications

- Modified the top-level Makefile so that sections of commands were clearer.
- Moved information around in the developer guidelines to make the instructions more clear. Also removed outdated commands and deprecated information about annotations.