### PR TITLE
Added embedding switch animations

### DIFF
--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -842,7 +842,10 @@ class Graph extends React.Component<{}, GraphState> {
       needToRenderCanvas = true;
     }
     if (positionsEnd !== prevAsyncProps?.positions) {
-      pointBufferStart({ data: positionsStart, dimension: 2 });
+      pointBufferStart({
+        data: this.duration === 0 ? positionsEnd : positionsStart,
+        dimension: 2,
+      });
       pointBufferEnd({ data: positionsEnd, dimension: 2 });
       needToRenderCanvas = true;
     }

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -15,6 +15,8 @@ export const DATASET_MAX_CELL_COUNT = 2_000_000;
 /* Category name suffix used to determine if category name is ontology term id. */
 export const ONTOLOGY_KEY = "ontology_term_id";
 
+export const animationLength = 750;
+
 /* Added to Portal links from breadcrumbs if there is work in progress */
 export const QUERY_PARAM_EXPLAIN_NEW_TAB = "explainNewTab";
 


### PR DESCRIPTION
Relevant issue:
https://github.com/chanzuckerberg/cellxgene/issues/944

The goal is to smoothly animate points when changing layouts for capturing cell persistence (i.e. visualizing how cells are related between embeddings).

@colinmegill
Could you ping anyone else who should review?

I modified `components/graph/graph.tsx,drawPointsRegl.ts` and `globals.ts`. We are using `regl.frame` to animate the canvas (adopted from [here](https://bl.ocks.org/pbeshai/66f1a837ec33f787dace43e1b5039e31)).

Demo:
https://user-images.githubusercontent.com/16548075/172991514-0a690607-a5b3-4043-8210-b9d68680dcc4.mov

