### PR TITLE
chore: gene info icon and minor design changes

### DIFF
--- a/client/src/components/geneExpression/gene.tsx
+++ b/client/src/components/geneExpression/gene.tsx
@@ -2,13 +2,12 @@ import React from "react";
 
 import { Button, Icon } from "@blueprintjs/core";
 import { connect } from "react-redux";
+import { Icon as InfoCircle } from "czifui";
 import Truncate from "../util/truncate";
 import HistogramBrush from "../brushableHistogram";
 import { RootState } from "../../reducers";
 
 import actions from "../../actions";
-import { IconNames as CXGIconNames } from "../icon";
-import CustomIcon from "../icon/icon";
 
 import { track } from "../../analytics";
 import { EVENTS } from "../../analytics/events";
@@ -164,19 +163,6 @@ class Gene extends React.Component<Props, State> {
               width: "100%",
             }}
           >
-            <div style={{ flexShrink: 0 }}>
-              <Button
-                minimal
-                small
-                data-testid={`get-info-${gene}`}
-                onClick={this.handleDisplayGeneInfo}
-                active={isGeneInfo}
-                intent={isGeneInfo ? "primary" : "none"}
-                style={{ paddingBottom: "3px" }}
-              >
-                <CustomIcon icon={CXGIconNames.ABOUT} />
-              </Button>
-            </div>
             <div>
               <Truncate
                 tooltipAddendum={geneDescription && `: ${geneDescription}`}
@@ -191,6 +177,24 @@ class Gene extends React.Component<Props, State> {
                   {gene}
                 </span>
               </Truncate>
+            </div>
+            <div style={{ flexShrink: 0 }}>
+              <Button
+                minimal
+                small
+                data-testid={`get-info-${gene}`}
+                onClick={this.handleDisplayGeneInfo}
+                active={isGeneInfo}
+                intent={isGeneInfo ? "primary" : "none"}
+              >
+                <div style={{ filter: "grayscale(100%)" }}>
+                  <InfoCircle
+                    sdsIcon="infoCircle"
+                    sdsSize="s"
+                    sdsType="static"
+                  />
+                </div>
+              </Button>
             </div>
             {!geneIsExpanded ? (
               <HistogramBrush

--- a/client/src/components/geneExpression/gene.tsx
+++ b/client/src/components/geneExpression/gene.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 
 import { Button, Icon } from "@blueprintjs/core";
-import { Icon as InfoCircle } from "czifui";
 import { connect } from "react-redux";
 import Truncate from "../util/truncate";
 import HistogramBrush from "../brushableHistogram";
 import { RootState } from "../../reducers";
 
 import actions from "../../actions";
+import { IconNames as CXGIconNames } from "../icon";
+import CustomIcon from "../icon/icon";
 
 import { track } from "../../analytics";
 import { EVENTS } from "../../analytics/events";
@@ -163,19 +164,20 @@ class Gene extends React.Component<Props, State> {
               width: "100%",
             }}
           >
+            <div style={{ flexShrink: 0 }}>
+              <Button
+                minimal
+                small
+                data-testid={`get-info-${gene}`}
+                onClick={this.handleDisplayGeneInfo}
+                active={isGeneInfo}
+                intent={isGeneInfo ? "primary" : "none"}
+                style={{ paddingBottom: "3px" }}
+              >
+                <CustomIcon icon={CXGIconNames.ABOUT} />
+              </Button>
+            </div>
             <div>
-              {!quickGene && (
-                <Icon
-                  icon="drag-handle-horizontal"
-                  iconSize={12}
-                  style={{
-                    marginRight: 7,
-                    cursor: "grab",
-                    position: "relative",
-                    top: -1,
-                  }}
-                />
-              )}
               <Truncate
                 tooltipAddendum={geneDescription && `: ${geneDescription}`}
               >
@@ -189,18 +191,6 @@ class Gene extends React.Component<Props, State> {
                   {gene}
                 </span>
               </Truncate>
-            </div>
-            <div>
-              <Button
-                minimal
-                small
-                data-testid={`get-info-${gene}`}
-                onClick={this.handleDisplayGeneInfo}
-                active={isGeneInfo}
-                intent={isGeneInfo ? "primary" : "none"}
-              >
-                <InfoCircle sdsIcon="infoCircle" sdsSize="s" sdsType="static" />
-              </Button>
             </div>
             {!geneIsExpanded ? (
               <HistogramBrush

--- a/client/src/components/geneExpression/geneInfo/geneInfo.tsx
+++ b/client/src/components/geneExpression/geneInfo/geneInfo.tsx
@@ -12,6 +12,8 @@ import {
 import * as styles from "../util";
 import { RootState } from "../../../reducers";
 import * as globals from "../../../globals";
+import { IconNames as CXGIconNames } from "../../icon";
+import CustomIcon from "../../icon/icon";
 
 type State = RootState;
 
@@ -98,7 +100,7 @@ class GeneInfo extends React.PureComponent<Props, State> {
             top: styles.margin.bottom / 2,
           }}
         >
-          Gene Info
+          <CustomIcon icon={CXGIconNames.ABOUT} /> Gene Info
         </GeneHeader>
         <ButtonGroup
           style={{

--- a/client/src/components/geneExpression/geneInfo/geneInfo.tsx
+++ b/client/src/components/geneExpression/geneInfo/geneInfo.tsx
@@ -12,8 +12,6 @@ import {
 import * as styles from "../util";
 import { RootState } from "../../../reducers";
 import * as globals from "../../../globals";
-import { IconNames as CXGIconNames } from "../../icon";
-import CustomIcon from "../../icon/icon";
 
 type State = RootState;
 
@@ -100,7 +98,7 @@ class GeneInfo extends React.PureComponent<Props, State> {
             top: styles.margin.bottom / 2,
           }}
         >
-          <CustomIcon icon={CXGIconNames.ABOUT} /> Gene Info
+          Gene Info
         </GeneHeader>
         <ButtonGroup
           style={{

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -121,6 +121,7 @@ export const graphWidth = 700;
 export const graphHeight = 700;
 export const scatterplotMarginLeft = 11;
 
+/* graph width + right sidebar width + left sidebar width is just below 1440p */
 export const rightSidebarWidth = 365;
 export const leftSidebarWidth = 365;
 export const leftSidebarSectionHeading = {


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@colinmegill @hthomas-czi 
**Readability:** 

---

## Changes
- replace drag handle in genesets with gene info button
- add gene info icon at top right of pop-up
- make gene info icon not primary color (until clicked)

## Notes for Reviewer
To save space on the right sidebar, replaced the unused drag handle in genesets with the gene info icon. Changed the icon to grayscale, since it's not a primary action. Added icon to the top left of gene info card for continuity. Considering changing the info icon to something less general (for example, a document), especially since the info icon is already used in "About cellxgene" in the menu. @hthomas-czi @colinmegill What are your thoughts on these changes?
