### PR TITLE
feat: Fargate support

### DIFF
--- a/.happy/terraform/envs/dev/main.tf
+++ b/.happy/terraform/envs/dev/main.tf
@@ -16,7 +16,8 @@ module stack {
   require_okta                 = false
   stack_prefix                 = "/${var.stack_name}"
   batch_container_memory_limit = 28000
-  memory                       = 50000
+  memory                       = 30720
+  cpu                          = 4096
 
   api_domain                   = "api.${local.domain}"
   web_domain                   = "${local.domain}"

--- a/.happy/terraform/envs/prod/main.tf
+++ b/.happy/terraform/envs/prod/main.tf
@@ -16,7 +16,8 @@ module stack {
   require_okta                 = false
   stack_prefix                 = "/${var.stack_name}"
   batch_container_memory_limit = 28000
-  memory                       = 50000
+  memory                       = 30720
+  cpu                          = 4096
   explorer_instance_count      = 3
 
   api_domain                   = "api.${local.domain}"

--- a/.happy/terraform/envs/rdev/main.tf
+++ b/.happy/terraform/envs/rdev/main.tf
@@ -12,6 +12,8 @@ module stack {
   require_okta                 = true
   stack_prefix                 = "/${var.stack_name}"
   batch_container_memory_limit = 28000
+  memory                       = 30720
+  cpu                          = 4096
 
   api_domain                   = "${var.stack_name}-explorer.rdev.single-cell.czi.technology"
   web_domain                   = "${var.stack_name}-explorer.rdev.single-cell.czi.technology"

--- a/.happy/terraform/envs/staging/main.tf
+++ b/.happy/terraform/envs/staging/main.tf
@@ -16,7 +16,8 @@ module stack {
   require_okta                 = false
   stack_prefix                 = "/${var.stack_name}"
   batch_container_memory_limit = 28000
-  memory                       = 50000
+  memory                       = 30720
+  cpu                          = 4096
   explorer_instance_count      = 2
 
 

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -21,6 +21,7 @@ locals {
   security_groups                 = local.secret["security_groups"]
   zone                            = local.secret["zone_id"]
   cluster                         = local.secret["cluster_arn"]
+  ecs_execution_role              = lookup(local.secret, "ecs_execution_role", "")
   external_dns                    = local.secret["external_zone_name"]
   internal_dns                    = local.secret["internal_zone_name"]
 
@@ -66,6 +67,7 @@ module explorer_service {
   task_role_arn         = local.ecs_role_arn
   service_port          = 5000
   memory                = var.memory
+  cpu                   = var.cpu
   cmd                   = local.explorer_cmd
   deployment_stage      = local.deployment_stage
   health_check_path     = "/cellxgene/health"
@@ -77,6 +79,7 @@ module explorer_service {
   cxg_bucket_path       = length(var.cxg_bucket_path) > 0 ? var.cxg_bucket_path : local.cellxgene_bucket
   frontend_url          = local.frontend_url
   remote_dev_prefix     = local.remote_dev_prefix
+  execution_role        = local.ecs_execution_role
 
   wait_for_steady_state = local.wait_for_steady_state
 }

--- a/.happy/terraform/modules/ecs-stack/variables.tf
+++ b/.happy/terraform/modules/ecs-stack/variables.tf
@@ -85,7 +85,13 @@ variable explorer_instance_count {
 variable memory {
   type        = number
   description = "Allocated memory"
-  default     = 1536
+  default     = 2048
+}
+
+variable cpu {
+  type        = number
+  description = "CPU shares (1cpu=1024) per task"
+  default     = 2048
 }
 
 variable "api_domain" {

--- a/.happy/terraform/modules/service/main.tf
+++ b/.happy/terraform/modules/service/main.tf
@@ -7,7 +7,7 @@ resource aws_ecs_service service {
   cluster         = var.cluster
   desired_count   = var.desired_count
   task_definition = aws_ecs_task_definition.task_definition.id
-  launch_type     = "EC2"
+  launch_type     = "FARGATE"
   name            = "${var.custom_stack_name}-${var.app_name}"
   load_balancer {
     container_name   = "web"
@@ -26,7 +26,13 @@ resource aws_ecs_service service {
 resource aws_ecs_task_definition task_definition {
   family        = "explorer-${var.deployment_stage}-${var.custom_stack_name}-${var.app_name}"
   network_mode  = "awsvpc"
-  task_role_arn = var.task_role_arn
+
+  memory                   = var.memory
+  cpu                      = var.cpu
+  task_role_arn            = var.task_role_arn
+  execution_role_arn       = var.execution_role
+  requires_compatibilities = ["FARGATE"]
+
   container_definitions = <<EOF
 [
   {
@@ -76,6 +82,7 @@ resource aws_ecs_task_definition task_definition {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
+        "awslogs-stream-prefix" : "fargate",
         "awslogs-group": "${aws_cloudwatch_log_group.cloud_watch_logs_group.id}",
         "awslogs-region": "${data.aws_region.current.name}"
       }

--- a/.happy/terraform/modules/service/variables.tf
+++ b/.happy/terraform/modules/service/variables.tf
@@ -121,6 +121,12 @@ variable "memory" {
   default     = 2048
 }
 
+variable "cpu" {
+  type        = number
+  description = "CPU shares (1cpu=1024) per task"
+  default     = 2048
+}
+
 variable "wait_for_steady_state" {
   type        = bool
   description = "Whether Terraform should block until the service is in a steady state before exiting"
@@ -136,4 +142,10 @@ variable "health_check_path" {
 variable "frontend_url" {
   type        = string
   description = "URL for the frontend app."
+}
+
+variable "execution_role" {
+  type        = string
+  description = "Execution role to use for fargate tasks - required for fargate services!"
+  default     = ""
 }


### PR DESCRIPTION
Currently explorer fails with

```
[2022-07-15 18:01:54 +0000] [1] [INFO] Shutting down: Master
/usr/local/lib/python3.8/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.5) or chardet (3.0.4) doesn't match a supported version!
warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
[2022-07-15 18:01:54 +0000] [9] [INFO] Worker exiting (pid: 9)
open config
[2022-07-15 18:01:53 +0000] [1] [INFO] Handling signal: term
[2022-07-15 17:59:08 +0000] [9] [INFO] Booting worker with pid: 9
[2022-07-15 17:59:08 +0000] [1] [INFO] Starting gunicorn 20.0.4
[2022-07-15 17:59:08 +0000] [1] [INFO] Listening at: http://0.0.0.0:5000 (1)
[2022-07-15 17:59:08 +0000] [1] [INFO] Using worker: gevent
```