### PR TITLE
fix: added flag to avoid calculating centroid if overlay isn't displayed

### DIFF
--- a/client/src/components/graph/overlays/centroidLabels.tsx
+++ b/client/src/components/graph/overlays/centroidLabels.tsx
@@ -42,7 +42,7 @@ export default class CentroidLabels extends PureComponent {
     const { colorAccessor } = colors;
     const [layoutDf, colorDf] = await this.fetchData();
     let labels;
-    if (colorDf) {
+    if (colorDf && showLabels) {
       labels = calcCentroid(
         schema,
         colorAccessor,


### PR DESCRIPTION
Calculating centroids took ~75% of every first color-by. For example, in the 4m cell dataset, coloring by a categorical for the first time took 2 seconds, 1.5 of which are the centroids. 

This PR makes it so centroids are only calculated if the overlay is displayed.

Part of this epic: #327 