### PR TITLE
fix: make push rdev use happy go client

### DIFF
--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -21,9 +21,6 @@ env:
 jobs:
   build-push-images:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        component: ['explorer']
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -38,13 +35,14 @@ jobs:
         with:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
+      - name: Install happy
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
+        with:
+          happy_version: "0.25.0"
       - name: Build component
         shell: bash
         run: |
-          pip install -r .happy/requirements.txt
-          # set tag from GITHUB_REF, but removing `refs/heads/` prefix
           DOCKER_TAG=${GITHUB_REF#refs/heads/}
           DOCKER_TAG=${DOCKER_TAG#refs/tags/}
-          # replace `/` with `_`
-          DOCKER_TAG=${DOCKER_TAG//\//-}
-          scripts/happy --profile="" push --stack-name ${DOCKER_TAG} --extra-tag sha-${GITHUB_SHA:0:8} --extra-tag build-${GITHUB_RUN_NUMBER} ${{ matrix.component }}
+          DOCKER_TAG=${DOCKER_TAG//\//-}        
+          happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} --tag ${DOCKER_TAG}

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -44,5 +44,6 @@ jobs:
         run: |
           DOCKER_TAG=${GITHUB_REF#refs/heads/}
           DOCKER_TAG=${DOCKER_TAG#refs/tags/}
+           # replace `/` with `_`
           DOCKER_TAG=${DOCKER_TAG//\//-}        
           happy push --aws-profile "" --tag sha-${GITHUB_SHA:0:8} --tag ${DOCKER_TAG}

--- a/.happy/requirements.txt
+++ b/.happy/requirements.txt
@@ -1,4 +1,0 @@
-click==7.1.2
-pyyaml==5.4.1
-terrasnek==0.1.2
-boto3==1.17.47


### PR DESCRIPTION
Switches the workflow to use the go client. 

This successful run uses the yaml copied into this PR: https://github.com/chanzuckerberg/single-cell-explorer/actions/runs/2719326953

#### Reviewers
**Functional:** 
@atolopko-czi 