### PR TITLE
feat: gene info api callback

### DIFF
--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -144,6 +144,7 @@ interface GeneInfoAPI {
   name: string;
   synonyms: string[];
   summary: string;
+  is_ensembl_id_result: boolean;
 }
 /**
  * Fetch gene summary information

--- a/client/src/components/geneExpression/gene.tsx
+++ b/client/src/components/geneExpression/gene.tsx
@@ -117,6 +117,7 @@ class Gene extends React.Component<Props, State> {
       synonyms: info.synonyms,
       summary: info.summary,
       infoError: null,
+      isEnsemblIdResult: info.is_ensembl_id_result,
     });
   };
 

--- a/client/src/components/geneExpression/geneInfo/geneInfo.tsx
+++ b/client/src/components/geneExpression/geneInfo/geneInfo.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { Button, ButtonGroup } from "@blueprintjs/core";
+import { Icon } from "czifui";
 import {
   SynHeader,
   Synonyms,
@@ -9,6 +10,7 @@ import {
   GeneSymbol,
   GeneHeader,
   GeneInfoWrapper,
+  WarningBanner,
 } from "./style";
 import * as styles from "../util";
 import { RootState } from "../../../reducers";
@@ -22,6 +24,7 @@ interface Props {
   gene: string;
   geneUrl: string;
   geneSynonyms: string[];
+  isEnsemblIdResult: boolean;
 }
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
@@ -36,6 +39,7 @@ interface Props {
     geneIsMinimized,
     geneLevel,
     infoError,
+    isEnsemblIdResult,
   } = state.controls;
 
   return {
@@ -48,6 +52,7 @@ interface Props {
     geneIsMinimized,
     geneLevel,
     infoError,
+    isEnsemblIdResult,
   };
 })
 class GeneInfo extends React.PureComponent<Props, State> {
@@ -66,6 +71,7 @@ class GeneInfo extends React.PureComponent<Props, State> {
       geneLevel,
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'infoError' does not exist on type '{ chi... Remove this comment to see the full error message
       infoError,
+      isEnsemblIdResult,
     } = this.props;
 
     const minimized = geneIsMinimized;
@@ -182,6 +188,18 @@ class GeneInfo extends React.PureComponent<Props, State> {
                 marginBottom: styles.margin.bottom,
               }}
             >
+              {!isEnsemblIdResult ? (
+                <WarningBanner>
+                  <Icon
+                    sdsIcon="exclamationMarkCircle"
+                    sdsSize="l"
+                    sdsType="static"
+                  />
+                  <span>
+                    NCBI didn&apos;t return an exact match for this gene.
+                  </span>
+                </WarningBanner>
+              ) : null}
               <GeneSymbol>{gene}</GeneSymbol>
               <Content>{geneName}</Content>
               {geneSummary === "" ? (

--- a/client/src/components/geneExpression/geneInfo/style.ts
+++ b/client/src/components/geneExpression/geneInfo/style.ts
@@ -85,3 +85,22 @@ export const Link = styled.a`
         `;
   }}
 `;
+
+export const WarningBanner = styled.div`
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  span {
+    margin-left: 10px;
+  }
+  ${fontBodyXs}
+  ${(props) => {
+    const colors = getColors(props);
+    return `
+        background-color: ${colors?.warning[100]};
+        svg {
+          fill: ${colors?.warning[400]}
+        }
+        `;
+  }}
+`;

--- a/client/src/components/leftSidebar/index.tsx
+++ b/client/src/components/leftSidebar/index.tsx
@@ -56,6 +56,7 @@ class LeftSideBar extends React.Component {
             gene=""
             geneUrl=""
             geneSynonyms={[]}
+            isEnsemblIdResult
           />
         ) : null}
       </div>

--- a/client/src/reducers/controls.ts
+++ b/client/src/reducers/controls.ts
@@ -166,6 +166,7 @@ const Controls = (
           geneIsMinimized: state.geneIsMinimized,
           geneLevel: state.geneLevel,
           infoError: state.infoError,
+          isEnsemblIdResult: action.isEnsemblIdResult,
         };
       }
       return {
@@ -179,6 +180,7 @@ const Controls = (
         geneIsMinimized: false,
         geneLevel: state.geneLevel,
         infoError: action.infoError,
+        isEnsemblIdResult: action.isEnsemblIdResult,
       };
     }
 


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@seve 
**Readability:** 

---

## Changes
- add warning banner for gene info responses that are not from ensembl ID
- incorporate new endpoint variable (is_ensembl_id_result) into logic

## Notes for Reviewer
If NCBI does not initially return a response to a gene ID search, the data portal endpoint will search via gene name instead. If this search has only 1 result, we will show this result. However, these are not exact matches to ENSEMBL IDs, so this PR adds a warning banner for these responses that says "NCBI did not return an exact result to this gene"
