### PR TITLE
fix: change path for static font files

### DIFF
--- a/client/configuration/webpack/webpack.config.prod.js
+++ b/client/configuration/webpack/webpack.config.prod.js
@@ -60,7 +60,7 @@ const prodConfig = {
         options: {
           name: "static/assets/[name]-[contenthash].[ext]",
           // (thuang): This is needed to make sure @font url path is '../static/assets/'
-          publicPath: "static/",
+          publicPath: "..",
         },
       },
     ],


### PR DESCRIPTION
#### Reviewers
**Functional:** 
@seve 
**Readability:** 

---

## Changes
- modify public path on webpack for static font files

## Notes for Reviewer
Font files are being accessed currently on prod / dev by an incorrect URL path (duplicate /static/ folders), so this hopefully fixes that
