### PR TITLE
feat: add cellxgene schema 3.0.0 fields to Standard Categories

### DIFF
--- a/client/src/common/types/entities.ts
+++ b/client/src/common/types/entities.ts
@@ -15,6 +15,8 @@ export const STANDARD_CATEGORY_NAMES = [
   "disease_ontology_term_id",
   "ethnicity",
   "ethnicity_ontology_term_id",
+  "self_reported_ethnicity",
+  "self_reported_ethnicity_ontology_term_id",
   "is_primary_data",
   "organism",
   "organism_ontology_term_id",
@@ -22,6 +24,8 @@ export const STANDARD_CATEGORY_NAMES = [
   "sex",
   "tissue_ontology_term_id",
   "tissue",
+  "suspension_type",
+  "donor_id",
 ];
 
 /**

--- a/server/tests/fixtures/test_bad_config.yaml
+++ b/server/tests/fixtures/test_bad_config.yaml
@@ -14,7 +14,7 @@ obs:
     tissue_ontology_term_id: UBERON:12345
     assay_ontology_term_id: EFO:12345
     disease_ontology_term_id: MONDO:12345
-    ethnicity_ontology_term_id: MANCESTRO:12345
+    self_reported_ethnicity_ontology_term_id: MANCESTRO:12345
     development_stage_ontology_term_id: HsapDv:12345
     sex: other
 uns:

--- a/server/tests/fixtures/test_config.yaml
+++ b/server/tests/fixtures/test_config.yaml
@@ -14,7 +14,7 @@ obs:
     tissue_ontology_term_id: UBERON:12345
     assay_ontology_term_id: EFO:12345
     disease_ontology_term_id: MONDO:12345
-    ethnicity_ontology_term_id: HANCESTRO:12345
+    self_reported_ethnicity_ontology_term_id: HANCESTRO:12345
     development_stage_ontology_term_id: HsapDv:12345
     sex: other
 uns:


### PR DESCRIPTION
[331](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell/331)
[336](https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/chanzuckerberg/single-cell/336)

#### Reviewers
**Functional:** 

**Readability:** 

---

## Changes
- Add 'donor_Id' to Standard Categories
- Add 'suspension_type' to Standard Categories
- Add 'self_reported_ethnicity' and 'self_reported_ethnicity_ontology_term_id' to Standard Categories. 
- Note: in the interim, we will support both 'ethnicity' and 'self_reported_ethnicity' fields in Standard Categories. Once the data portal is migrated over to 3.0.0, we will remove support for ethnicity as a Standard Category (as it will be a deprecated column name in cellxgene schema 3.0.0 in favor of self_reported_ethnicity)

## QA
- Will test locally with a 3.0.0 and 2.0.0 dataset, to ensure expected new behavior and no regressions
