### PR TITLE
refactor(cascadeReducer): Quick feedback 2

### DIFF
--- a/client/src/reducers/categoricalSelection.ts
+++ b/client/src/reducers/categoricalSelection.ts
@@ -20,7 +20,7 @@ const CategoricalSelection = (
   state: CategoricalSelectionState,
   action: AnyAction,
   nextSharedState: RootState
-) => {
+): CategoricalSelectionState => {
   switch (action.type) {
     case "initial data load complete":
     case "subset to selection":

--- a/client/src/reducers/centroidLabels.ts
+++ b/client/src/reducers/centroidLabels.ts
@@ -1,4 +1,5 @@
-import type { Action } from "redux";
+import type { Action, AnyAction } from "redux";
+import type { RootState } from ".";
 
 export interface CentroidLabelsState {
   showLabels: boolean;
@@ -14,15 +15,15 @@ const initialState: CentroidLabelsState = {
 
 const centroidLabels = (
   state = initialState,
-  action: CentroidLabelsAction,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  sharedNextState: any
+  action: AnyAction,
+  sharedNextState: RootState
 ): CentroidLabelsState => {
   const {
     colors: { colorAccessor },
   } = sharedNextState;
 
-  const showLabels = action.showLabels ?? state.showLabels;
+  const showLabels =
+    (action as CentroidLabelsAction).showLabels ?? state.showLabels;
 
   switch (action.type) {
     case "color by categorical metadata":

--- a/client/src/reducers/continuousSelection.ts
+++ b/client/src/reducers/continuousSelection.ts
@@ -1,4 +1,4 @@
-import type { Action } from "redux";
+import type { Action, AnyAction } from "redux";
 
 import { makeContinuousDimensionName } from "../util/nameCreators";
 
@@ -16,7 +16,7 @@ export interface ContinuousSelectionState {
 
 const ContinuousSelection = (
   state: ContinuousSelectionState = {},
-  action: ContinuousSelectionAction
+  action: AnyAction
 ): ContinuousSelectionState => {
   switch (action.type) {
     case "reset subset":
@@ -27,20 +27,20 @@ const ContinuousSelection = (
     case "continuous metadata histogram start":
     case "continuous metadata histogram brush":
     case "continuous metadata histogram end": {
-      const name = makeContinuousDimensionName(
-        action.continuousNamespace,
-        action.selection
-      );
+      const { continuousNamespace, selection, range } =
+        action as ContinuousSelectionAction;
+
+      const name = makeContinuousDimensionName(continuousNamespace, selection);
       return {
         ...state,
-        [name]: action.range,
+        [name]: range,
       };
     }
     case "continuous metadata histogram cancel": {
-      const name = makeContinuousDimensionName(
-        action.continuousNamespace,
-        action.selection
-      );
+      const { continuousNamespace, selection } =
+        action as ContinuousSelectionAction;
+
+      const name = makeContinuousDimensionName(continuousNamespace, selection);
       const { [name]: deletedField, ...newState } = state;
       return newState;
     }

--- a/client/src/reducers/datasetMetadata.ts
+++ b/client/src/reducers/datasetMetadata.ts
@@ -1,9 +1,9 @@
 /*
- Dataset metadata reducer, modifies Portal collections-related state. 
+ Dataset metadata reducer, modifies Portal collections-related state.
  */
 
 // Core dependencies
-import { Action } from "redux";
+import { Action, AnyAction } from "redux";
 
 // App dependencies
 import { DatasetMetadata as IDatasetMetadata } from "../common/types/entities";
@@ -11,14 +11,14 @@ import { DatasetMetadata as IDatasetMetadata } from "../common/types/entities";
 /*
  Action dispatched on successful response from dataset-metadata endpoint.
  */
-export interface DatasetMetdataAction extends Action<string> {
+export interface DatasetMetadataAction extends Action<string> {
   datasetMetadata: IDatasetMetadata;
   error: string;
   portalUrl: string;
 }
 
 /*
- Dataset metdata state; selected dataset ID and corresponding collection information.
+ Dataset metadata state; selected dataset ID and corresponding collection information.
  */
 export interface DatasetMetadataState {
   datasetMetadata: IDatasetMetadata | null;
@@ -36,7 +36,7 @@ const DatasetMetadata = (
     datasetMetadata: null,
     portalUrl: null,
   },
-  action: DatasetMetdataAction
+  action: AnyAction
 ): DatasetMetadataState => {
   switch (action.type) {
     case "initial data load start":
@@ -45,19 +45,25 @@ const DatasetMetadata = (
         loading: true,
         error: null,
       };
-    case "dataset metadata load complete":
+    case "dataset metadata load complete": {
+      const { datasetMetadata, portalUrl } = action as DatasetMetadataAction;
+
       return {
         ...state,
         loading: false,
         error: null,
-        datasetMetadata: action.datasetMetadata,
-        portalUrl: action.portalUrl,
+        datasetMetadata,
+        portalUrl,
       };
-    case "initial data load error":
+    }
+    case "initial data load error": {
+      const { error } = action as DatasetMetadataAction;
+
       return {
         ...state,
-        error: action.error,
+        error,
       };
+    }
     default:
       return state;
   }

--- a/client/src/reducers/layoutChoice.ts
+++ b/client/src/reducers/layoutChoice.ts
@@ -8,7 +8,8 @@ about commonly used names.  Preferentially, pick in the following order:
   4. give up, use the first available
 */
 
-import type { Action } from "redux";
+import type { Action, AnyAction } from "redux";
+import type { RootState } from ".";
 import { EmbeddingSchema, Schema } from "../common/types/schema";
 
 function bestDefaultLayout(layouts: Array<string>): string {
@@ -39,9 +40,8 @@ export interface LayoutChoiceAction extends Action<string> {
 
 const LayoutChoice = (
   state: LayoutChoiceState,
-  action: LayoutChoiceAction,
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,  @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-  nextSharedState: any
+  action: AnyAction,
+  nextSharedState: RootState
 ): LayoutChoiceState => {
   switch (action.type) {
     case "initial data load complete": {
@@ -55,7 +55,7 @@ const LayoutChoice = (
 
     case "set layout choice": {
       const { schema } = nextSharedState.annoMatrix;
-      const current = action.layoutChoice;
+      const current = (action as LayoutChoiceAction).layoutChoice;
       const currentDimNames = schema.layout.obsByName[current].dims;
       return { ...state, current, currentDimNames };
     }

--- a/client/src/reducers/quickGenes.ts
+++ b/client/src/reducers/quickGenes.ts
@@ -1,23 +1,28 @@
 import uniq from "lodash.uniq";
 import filter from "lodash.filter";
+import { Action, AnyAction } from "redux";
 import type { RootState } from ".";
 import { track } from "../analytics";
 import { EVENTS } from "../analytics/events";
 
-interface QuickGenesActions {
-  type: string;
+interface State {
+  userDefinedGenes: string[];
+  userDefinedGenesLoading: boolean;
+}
+
+interface QuickGenesActions extends Action<string> {
   gene: string;
   selection: string;
   data: string;
 }
 const quickGenes = (
-  state: { userDefinedGenes: string[]; userDefinedGenesLoading: boolean } = {
+  state: State = {
     userDefinedGenes: [],
     userDefinedGenesLoading: false,
   },
-  action: QuickGenesActions,
+  action: AnyAction,
   nextSharedState: RootState
-) => {
+): State => {
   switch (action.type) {
     case "request user defined gene started": {
       return {
@@ -33,7 +38,10 @@ const quickGenes = (
     }
     case "request user defined gene success": {
       const { userDefinedGenes } = state;
-      const _userDefinedGenes = uniq([...userDefinedGenes, action.gene]);
+      const { gene } = action as QuickGenesActions;
+
+      const _userDefinedGenes = uniq([...userDefinedGenes, gene]);
+
       return {
         ...state,
         userDefinedGenes: _userDefinedGenes,
@@ -42,10 +50,10 @@ const quickGenes = (
     }
     case "clear user defined gene": {
       const { userDefinedGenes } = state;
-      const newUserDefinedGenes = filter(
-        userDefinedGenes,
-        (d) => d !== action.gene
-      );
+      const { gene } = action as QuickGenesActions;
+
+      const newUserDefinedGenes = filter(userDefinedGenes, (d) => d !== gene);
+
       return {
         ...state,
         userDefinedGenes: newUserDefinedGenes,
@@ -56,7 +64,7 @@ const quickGenes = (
     case "color by expression":
     case "set scatterplot x":
     case "set scatterplot y": {
-      const { selection, gene } = action;
+      const { selection, gene } = action as QuickGenesActions;
       const { controls } = nextSharedState;
       const { scatterplotXXaccessor, scatterplotYYaccessor } = controls;
 


### PR DESCRIPTION
This is probably the closest we could get to typing actions without using [Redux Toolkit](https://redux.js.org/usage/usage-with-typescript#overview), which is their strongly recommended way to do Redux now. 

The overall pattern is that each slice's reducer's `action` argument is `AnyAction`, since any action goes through every reducer. But in the switch case, we cast the action to the slice's action type, since such action type **should** come with the agreed payload. Note that this is NOT guaranteed at runtime, because Explorer is NOT using action creators to allow TypeScript to map the action type and payload statically. But such refactor would take a lot more time, so this is a compromise for now until we see a strong need to start using Redux Toolkit