### PR TITLE
fix: Fix behavior of annotation labels when continuous clipping is active.

### DIFF
--- a/client/src/util/dataframe/dataframe.ts
+++ b/client/src/util/dataframe/dataframe.ts
@@ -959,26 +959,12 @@ class Dataframe {
 
     callback MUST not modify the column, but instead return a mutated copy.
     */
-    const columns = this.__columns.map((colData, colIdx) => {
-      let data: DataframeValueArray;
-      // mapColumns will mutate dictionary encoded arrays into standard value arrays.
-      // This ensures that users will always be dealing with values in the callback.
-      // TODO: memoize this function to avoid repeated work.
-      if (isDictEncodedTypedArray(colData)) {
-        data = new Array(colData.length);
-        for (let i = 0; i < data.length; i += 1) {
-          data[i] = colData.vat(i);
-        }
-      } else {
-        data = colData;
-      }
-      return callback(
-        data,
+    const columns = this.__columns.map((colData, colIdx) => callback(
+        colData,
         colIdx,
         this.colIndex.getLabel(colIdx) as LabelType,
         this
-      );
-    });
+      ));
     const columnsAccessor: (DataframeColumn | null)[] = columns.map((c, idx) =>
       this.__columns[idx] === c ? this.__columnsAccessor[idx] : null
     );


### PR DESCRIPTION
Fixes #453 

Cause of the bug:
A change to `mapColumns` in `dataframe.ts`, where dictionary-encoded arrays are auto-converted to an array of their values, resulted in a mismatch between the column schema (still comprised of integers) and the column array (now comprised of values). This change was initially introduced in the dictionary-encoded flatbuffer PR so that engineers would not need to handle dictionary-encoded arrays specifically in the `mapColumns` callback (in `dataframe.ts`).

The clipping functionality uses `mapColumns` (the only place that uses this function) and returns the dataframe column without manipulation for categorical data. The dataframe column is now an array of values, but the schema still sees categories as integers.

The easiest fix is to simply revert `mapColumns` to its previous behavior. If `mapColumns` ever needed to be applied to categorical data in the future (it doesn't currently), engineers would now need to handle the dictionary encoded arrays in the callback. 