### PR TITLE
fix: remove platform spec from docker compose yaml to unblock deployments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
 
   explorer:
     image: "${DOCKER_REPO}corpora-explorer"
-    platform: linux/amd64
     build:
       context: .
       dockerfile: hosted/Dockerfile


### PR DESCRIPTION
See here for explanation: https://github.com/chanzuckerberg/single-cell-data-portal/pull/3351