### PR TITLE
fix: Fixes the continuous legend so it doesn't clear whenever the genesets change

### DIFF
--- a/client/src/components/continuousLegend/index.tsx
+++ b/client/src/components/continuousLegend/index.tsx
@@ -254,16 +254,19 @@ class ContinuousLegend extends React.Component<Props> {
         >
           <Async.Fulfilled>
             {(asyncProps: FetchedAsyncProps) => {
-              d3.select("#continuous_legend").selectAll("*").remove();
               if (
                 !shallowEqual(asyncProps, this.cachedAsyncProps) &&
                 asyncProps &&
                 asyncProps.colorMode &&
                 asyncProps.colorMode !== "color by categorical metadata"
               ) {
+                d3.select("#continuous_legend").selectAll("*").remove();
                 this.updateContinuousLegend(asyncProps);
               }
               this.cachedAsyncProps = asyncProps;
+              // if asyncProps is null (no colorAccessor), remove legend
+              if (!asyncProps)
+                d3.select("#continuous_legend").selectAll("*").remove();
               return null;
             }}
           </Async.Fulfilled>


### PR DESCRIPTION
Fixes: #442 
Updating genesets in any way would trigger the Async.Fulfilled component in the continuous legend where there was an unconditional/unguarded clearing of the legend. This was updated so that the legend only clears if `asyncProps` is null, meaning there is no color accessor defined.

#### Reviewers
@tihuan 