### PR TITLE
unfix: Revert "fix: Assume NavBar is present when calculating height of explorer initially."

### DIFF
--- a/client/src/components/framework/layout.tsx
+++ b/client/src/components/framework/layout.tsx
@@ -30,9 +30,7 @@ const Layout: React.FC<Props> = (props) => {
     <div
       style={{
         display: "grid",
-        // `??` is used so when `seamlessEnabled` is `undefined` or `true`, so we can add padding to prevent
-        // unneeded scrollbar
-        paddingTop: seamlessEnabled ?? true ? globals.HEADER_HEIGHT_PX : 0,
+        paddingTop: seamlessEnabled ? globals.HEADER_HEIGHT_PX : 0,
         gridTemplateColumns: `
         [left-sidebar-start] ${globals.leftSidebarWidth + 1}px
         [left-sidebar-end graph-start] auto


### PR DESCRIPTION
Reverts chanzuckerberg/single-cell-explorer#502

This did not solve the problem on `dev`.