### PR TITLE
chore: update happy actions to latest

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -49,12 +49,11 @@ jobs:
             echo "DEPLOYMENT_STAGE=dev" >> $GITHUB_ENV
           fi
       - name: Install happy client
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@v1.2.1
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
       - name: Update deployment
-        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.2.1
+        uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@deploy-happy-stack-v1.7.2
         with:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           stack-name: explorer-${{ env.DEPLOYMENT_STAGE }}stack
-          happy_version: "0.19.1"
           create-tag: "true"
           env: ${{ env.DEPLOYMENT_STAGE }} 

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -36,9 +36,7 @@ jobs:
           registry: ${{ secrets.ECR_REPO }}
       - uses: actions/checkout@v2
       - name: Install happy
-        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.2.1
-        with:
-          happy_version: "0.25.0"
+        uses: chanzuckerberg/github-actions/.github/actions/install-happy@install-happy-v1.4.2
       - name: Build component
         shell: bash
         run: |


### PR DESCRIPTION
## Reason for Change

Updates github actions for installing happy and deploying stacks to the latest available versions. This causes the actions to use the latest version of happy CLI which fixes some recent stacklist issues.