### PR TITLE
feat: increase zoom limits by a factor of 4

### DIFF
--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -46,15 +46,12 @@ export async function drag(testId: any, start: any, end: any, lasso = false) {
 export async function scroll({testId, deltaY, coords}: {testId: string, deltaY: number, coords: number[]}) {
   const layout = await waitByID(testId);
   if (layout){
-    const elBox = await layout.boxModel();
-    if (elBox) {
-      const x = coords[0];
-      const y = coords[1];
-      await page.mouse.move(x, y);
-      await page.mouse.down();
-      await page.mouse.up();
-      await page.mouse.wheel({ deltaY });
-    }
+    const x = coords[0];
+    const y = coords[1];
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.mouse.wheel({ deltaY });
   }
 }
 

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -43,6 +43,21 @@ export async function drag(testId: any, start: any, end: any, lasso = false) {
   await page.mouse.up();
 }
 
+export async function scroll({testId, deltaY, coords}: {testId: string, deltaY: number, coords: number[]}) {
+  const layout = await waitByID(testId);
+  if (layout){
+    const elBox = await layout.boxModel();
+    if (elBox) {
+      const x = coords[0];
+      const y = coords[1];
+      await page.mouse.move(x, y);
+      await page.mouse.down();
+      await page.mouse.up();
+      await page.mouse.wheel({ deltaY });
+    }
+  }
+}
+
 export async function keyboardUndo() {
   await page.keyboard.down("MetaLeft");
   await page.keyboard.press("KeyZ");

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -918,6 +918,7 @@ class Graph extends React.Component<{}, GraphState> {
           top: 0,
           left: 0,
         }}
+        data-test-id={`graph-wrapper-distance=${camera?.distance()}`}
       >
         <GraphOverlayLayer
           // @ts-expect-error ts-migrate(2322) FIXME: Type '{ children: Element; width: any; height: any... Remove this comment to see the full error message

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent } from "react";
+import React from "react";
 import * as d3 from "d3";
 import { connect, shallowEqual } from "react-redux";
 import { mat3, vec2 } from "gl-matrix";

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { MouseEvent } from "react";
 import * as d3 from "d3";
 import { connect, shallowEqual } from "react-redux";
 import { mat3, vec2 } from "gl-matrix";
@@ -125,6 +125,8 @@ class Graph extends React.Component<{}, GraphState> {
   static watchAsync(props: any, prevProps: any) {
     return !shallowEqual(props.watchProps, prevProps.watchProps);
   }
+
+  private graphRef = React.createRef<HTMLDivElement>();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
   cachedAsyncProps: any;
@@ -264,6 +266,11 @@ class Graph extends React.Component<{}, GraphState> {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentDidMount() {
     window.addEventListener("resize", this.handleResize);
+    if (this.graphRef.current) {
+      this.graphRef.current.addEventListener("wheel", this.disableScroll, {
+        passive: false,
+      });
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
@@ -323,6 +330,9 @@ class Graph extends React.Component<{}, GraphState> {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   componentWillUnmount() {
     window.removeEventListener("resize", this.handleResize);
+    if (this.graphRef.current) {
+      this.graphRef.current.removeEventListener("wheel", this.disableScroll);
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
@@ -495,6 +505,11 @@ class Graph extends React.Component<{}, GraphState> {
       data: e.target.value,
     });
   }
+
+  disableScroll = (event: WheelEvent) => {
+    // disables browser scrolling behavior when hovering over the graph
+    event.preventDefault();
+  };
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   setReglCanvas = (canvas: any) => {
@@ -910,6 +925,7 @@ class Graph extends React.Component<{}, GraphState> {
     } = this.props;
     const { modelTF, projectionTF, camera, viewport, regl } = this.state;
     const cameraTF = camera?.view()?.slice();
+
     return (
       <div
         id="graph-wrapper"
@@ -919,6 +935,7 @@ class Graph extends React.Component<{}, GraphState> {
           left: 0,
         }}
         data-test-id={`graph-wrapper-distance=${camera?.distance()}`}
+        ref={this.graphRef}
       >
         <GraphOverlayLayer
           // @ts-expect-error ts-migrate(2322) FIXME: Type '{ children: Element; width: any; height: any... Remove this comment to see the full error message

--- a/client/src/util/camera.ts
+++ b/client/src/util/camera.ts
@@ -4,7 +4,8 @@ import clamp from "./clamp";
 const EPSILON = 0.000001;
 
 const scaleSpeed = 0.5;
-const scaleMax = 12.0;
+// exporting this for testing
+export const scaleMax = 12.0;
 const scaleMin = 0.5;
 const panBound = 0.8;
 

--- a/client/src/util/camera.ts
+++ b/client/src/util/camera.ts
@@ -4,7 +4,7 @@ import clamp from "./clamp";
 const EPSILON = 0.000001;
 
 const scaleSpeed = 0.5;
-const scaleMax = 3.0;
+const scaleMax = 12.0;
 const scaleMin = 0.5;
 const panBound = 0.8;
 


### PR DESCRIPTION
## Changes
- increase zoom limit to 12x from 3x
- add smoke test for zoom
- prevent scrolling on graph component

## Testing
 - tested locally and smoke tested

## Notes for reviewer
Previously, scrolling behavior conflicts with zoom tool:
https://user-images.githubusercontent.com/16548075/231508562-a850bf9c-8861-442f-bdbc-122236288540.mov

Now, the rubberbanding scrolling behavior is no longer present on the graph component:
https://user-images.githubusercontent.com/16548075/231508671-2467c602-80b2-4d17-afd9-42eee2b294a2.mov

