### PR TITLE
Log failed responses from data portal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,9 @@ exclude = '''
 
 )
 '''
+
+[tool.ruff]
+select = ["E", "F", "B", "SIM", "C4", "I"]
+ignore = ["E501", "E402", "C408", ]
+line-length = 120
+target-version = "py38"

--- a/server/dataset/dataset_metadata.py
+++ b/server/dataset/dataset_metadata.py
@@ -124,24 +124,25 @@ def get_dataset_and_collection_metadata(dataset_root: str, dataset_id: str, app_
         suffix = "?visibility=PRIVATE" if collection_visibility == "PRIVATE" else ""
         suffix_for_url = "/private" if collection_visibility == "PRIVATE" else ""
 
-        res = requests.get(f"{data_locator_base_url}/collections/{collection_id}{suffix}").json()
-        if res.status_code != 200:
+        res = requests.get(f"{data_locator_base_url}/collections/{collection_id}{suffix}")
+        if not res.ok:
             log_error_response_from_data_portal(res)
+        res_json = res.json()
         web_base_url = app_config.server__app__web_base_url
         metadata = {
-            "dataset_name": [dataset["name"] for dataset in res["datasets"] if dataset["id"] == dataset_id][0],
+            "dataset_name": [dataset["name"] for dataset in res_json["datasets"] if dataset["id"] == dataset_id][0],
             "dataset_id": dataset_id,
             "collection_url": f"{web_base_url}/collections/{collection_id}{suffix_for_url}",
-            "collection_name": res["name"],
-            "collection_description": res["description"],
-            "collection_contact_email": res["contact_email"],
-            "collection_contact_name": res["contact_name"],
-            "collection_links": res["links"],
-            "collection_datasets": res["datasets"],
+            "collection_name": res_json["name"],
+            "collection_description": res_json["description"],
+            "collection_contact_email": res_json["contact_email"],
+            "collection_contact_name": res_json["contact_name"],
+            "collection_links": res_json["links"],
+            "collection_datasets": res_json["datasets"],
         }
 
-        if res.get("publisher_metadata"):
-            metadata["collection_publisher_metadata"] = res["publisher_metadata"]
+        if res_json.get("publisher_metadata"):
+            metadata["collection_publisher_metadata"] = res_json["publisher_metadata"]
 
         return metadata
 

--- a/server/tests/unit/common/apis/test_api_v3.py
+++ b/server/tests/unit/common/apis/test_api_v3.py
@@ -1,21 +1,20 @@
-import unittest
-from urllib.parse import quote
+import hashlib
 import json
 import os
 import time
+import unittest
 from http import HTTPStatus
-import hashlib
 from unittest.mock import patch
-import numpy as np
+from urllib.parse import quote
 
+import numpy as np
 import requests
 
 from server.common.config.app_config import AppConfig
-from server.tests import decode_fbs, FIXTURES_ROOT
+from server.common.diffexpdu import DiffExArguments
+from server.tests import FIXTURES_ROOT, decode_fbs
 from server.tests.fixtures.fixtures import pbmc3k_colors
 from server.tests.unit import BaseTest as _BaseTest
-from server.common.diffexpdu import DiffExArguments
-
 
 BAD_FILTER = {"filter": {"obs": {"annotation_value": [{"name": "xyz"}]}}}
 
@@ -52,7 +51,7 @@ class EndPoints(BaseTest):
         cls.app.testing = True
         cls.client = cls.app.test_client()
         os.environ["SKIP_STATIC"] = "True"
-        for i in range(90):
+        for _i in range(90):
             try:
                 result = cls.client.get(f"{cls.TEST_URL_BASE}schema")
                 cls.schema = json.loads(result.data)
@@ -60,7 +59,7 @@ class EndPoints(BaseTest):
             except requests.exceptions.ConnectionError:
                 time.sleep(1)
 
-        for i in range(90):
+        for _i in range(90):
             try:
                 result = cls.client.get(f"{cls.TEST_URL_BASE_SPARSE}schema")
                 cls.schema = json.loads(result.data)
@@ -141,7 +140,7 @@ class EndPoints(BaseTest):
                 self.assertCountEqual(
                     df["col_idx"],
                     [obs_index_col_name, "n_genes", "percent_mito", "n_counts", "louvain"],
-        )
+                )
 
     def test_get_annotations_obs_keys_fbs(self):
         endpoint = "annotations/obs"
@@ -260,7 +259,9 @@ class EndPoints(BaseTest):
                     set1=np.arange(0, 500, dtype=np.uint32),
                     set2=np.arange(500, 1000, dtype=np.uint32),
                 )
-                result = self.client.post(url, headers={"Content-Type": "application/octet-stream"}, data=de_args.pack())
+                result = self.client.post(
+                    url, headers={"Content-Type": "application/octet-stream"}, data=de_args.pack()
+                )
                 self.assertEqual(result.status_code, HTTPStatus.OK)
                 self.assertEqual(result.headers["Content-Type"], "application/json")
                 result_data = json.loads(result.data)
@@ -342,7 +343,9 @@ class EndPoints(BaseTest):
                 self.assertEqual(result.status_code, HTTPStatus.BAD_REQUEST)
 
                 # missing content length
-                result = self.client.post(url, content_length=False, headers={"Content-Type": "application/octet-stream"})
+                result = self.client.post(
+                    url, content_length=False, headers={"Content-Type": "application/octet-stream"}
+                )
                 self.assertEqual(result.status_code, HTTPStatus.LENGTH_REQUIRED)
 
                 # Content-Length too large
@@ -546,7 +549,7 @@ class EndPoints(BaseTest):
     def test_genesets_config(self):
         for url_base in [self.TEST_URL_BASE, self.TEST_URL_BASE_SPARSE]:
             with self.subTest(url_base=url_base):
-                url = f"{url_base}config"        
+                url = f"{url_base}config"
                 result = self.client.get(url)
                 config_data = json.loads(result.data)
                 params = config_data["config"]["parameters"]
@@ -584,7 +587,7 @@ class EndPoints(BaseTest):
         query = f"method=mean&{filter}"
         query_hash = hashlib.sha1(query.encode()).hexdigest()
         for url_base in [self.TEST_URL_BASE, self.TEST_URL_BASE_SPARSE]:
-            with self.subTest(url_base=url_base):        
+            with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?{query}"
                 header = {"Accept": "application/octet-stream"}
                 result = self.client.get(url, headers=header)
@@ -606,7 +609,7 @@ class EndPoints(BaseTest):
         query = f"method=mean&{filter}"
         query_hash = hashlib.sha1(query.encode()).hexdigest()
         for url_base in [self.TEST_URL_BASE, self.TEST_URL_BASE_SPARSE]:
-            with self.subTest(url_base=url_base):              
+            with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?key={query_hash}"
                 result = self.client.post(url, headers=headers, data=query)
 
@@ -624,7 +627,7 @@ class EndPoints(BaseTest):
         query = f"method=mean&{filter}"
         query_hash = hashlib.sha1(query.encode()).hexdigest()
         for url_base in [self.TEST_URL_BASE, self.TEST_URL_BASE_SPARSE]:
-            with self.subTest(url_base=url_base):               
+            with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?key={query_hash}"
                 result = self.client.post(url, headers=headers, data=query)
                 self.assertEqual(result.status_code, HTTPStatus.OK)
@@ -644,7 +647,7 @@ class EndPoints(BaseTest):
         query = f"method=mean&{filter}&nbins=500"
         query_hash = hashlib.sha1(query.encode()).hexdigest()
         for url_base in [self.TEST_URL_BASE, self.TEST_URL_BASE_SPARSE]:
-            with self.subTest(url_base=url_base):               
+            with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?{query}"
                 header = {"Accept": "application/octet-stream"}
                 result = self.client.get(url, headers=header)
@@ -662,7 +665,7 @@ class EndPoints(BaseTest):
         query = f"method=mean&{filter}&nbins=500"
         query_hash = hashlib.sha1(query.encode()).hexdigest()
         for url_base in [self.TEST_URL_BASE, self.TEST_URL_BASE_SPARSE]:
-            with self.subTest(url_base=url_base):               
+            with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?{query}"
                 header = {"Accept": "application/octet-stream"}
                 result = self.client.get(url, headers=header)
@@ -684,7 +687,7 @@ class EndPoints(BaseTest):
         query = f"method=mean&{filter}"
         query_hash = hashlib.sha1(query.encode()).hexdigest()
         for url_base in [self.TEST_URL_BASE, self.TEST_URL_BASE_SPARSE]:
-            with self.subTest(url_base=url_base):               
+            with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?key={query_hash}"
                 result = self.client.post(url, headers=headers, data=query)
 
@@ -702,7 +705,7 @@ class EndPoints(BaseTest):
         query = f"method=mean&{filter}&nbins=500"
         query_hash = hashlib.sha1(query.encode()).hexdigest()
         for url_base in [self.TEST_URL_BASE, self.TEST_URL_BASE_SPARSE]:
-            with self.subTest(url_base=url_base):               
+            with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?key={query_hash}"
                 result = self.client.post(url, headers=headers, data=query)
                 self.assertEqual(result.status_code, HTTPStatus.OK)
@@ -712,7 +715,6 @@ class EndPoints(BaseTest):
                 self.assertEqual(df["n_cols"], 1)
                 self.assertEqual(df["col_idx"], [query_hash])
                 self.assertAlmostEqual(df["columns"][0][0], -0.17065382)
-
 
 
 class TestDatasetMetadata(BaseTest):
@@ -984,9 +986,10 @@ class TestS3URI(BaseTest):
 
 
 class MockResponse:
-    def __init__(self, body, status_code):
+    def __init__(self, body, status_code, ok=True):
         self.content = body
         self.status_code = status_code
+        self.ok = ok
 
     def json(self):
         return json.loads(self.content)


### PR DESCRIPTION
This will help when debugging error between explorer and data portal. Most importantly it give us the request_id so we can correlate with the data portal logs.

- Update the pyproject.toml to include our current ruff configuration.