### PR TITLE
chore: fix local development

### DIFF
--- a/launch_dev_server.sh
+++ b/launch_dev_server.sh
@@ -8,5 +8,5 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
 export PYTHONPATH=${PROJECT_ROOT}  # permits module discovery when run from somewhere other than top level dir
 
-PROJECT_ROOT=${PROJECT_ROOT} python -m server.cli.launch $@
+PROJECT_ROOT=${PROJECT_ROOT} python -m server.cli.launch -d $@
 

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -68,7 +68,7 @@ def server_args(func):
         "--debug",
         "-d",
         is_flag=True,
-        default=DEFAULT_CONFIG.server__app__debug,
+        default=True,
         show_default=True,
         help="Run in debug mode. This is helpful for cellxgene developers, "
         "or when you want more information about an error condition.",

--- a/server/cli/launch.py
+++ b/server/cli/launch.py
@@ -68,7 +68,7 @@ def server_args(func):
         "--debug",
         "-d",
         is_flag=True,
-        default=True,
+        default=DEFAULT_CONFIG.server__app__debug,
         show_default=True,
         help="Run in debug mode. This is helpful for cellxgene developers, "
         "or when you want more information about an error condition.",

--- a/server/tests/unit/__init__.py
+++ b/server/tests/unit/__init__.py
@@ -47,7 +47,7 @@ class TestServer(Server):
         ]
         Compress(app)
         if app_config.server__app__debug:
-            CORS(app, supports_credentials=True)
+            CORS(app, supports_credentials=True, origins=[r"^http://localhost:\d+"])
 
     @staticmethod
     def _extract_base_url_and_dataset_for_api_calls(app_config: AppConfig):


### PR DESCRIPTION
Fixes local development bug introduced in #500 

Debug mode wasn't set properly as the CLI was updated to use the default config, in which debug is set to false. I updated `launch_dev_server.sh` to use `-d` flag to set debug.

I also added localhost as an allowed origin when debug is true.