### PR TITLE
chore: update Docker base image to ubuntu 22

### DIFF
--- a/hosted/Dockerfile
+++ b/hosted/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:22.04
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
@@ -8,7 +8,7 @@ ENV DEPLOYMENT_STAGE=$HAPPY_ENV
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y gettext nginx moreutils build-essential libxml2-dev python3-dev python3-pip zlib1g-dev python3-requests python3-aiohttp llvm jq npm git zip curl && \
+    apt-get install -y gettext nginx moreutils build-essential libxml2-dev python3-dev python3-pip zlib1g-dev python3-requests python3-aiohttp llvm jq git zip curl && \
     curl -sL https://deb.nodesource.com/setup_16.x  | bash - && \
     apt-get -y install nodejs && \
     node -v && \


### PR DESCRIPTION
Issue #564 

Update the Docker base image to Ubuntu 22. This implicitly brings the default Python version to 3.10.