### PR TITLE
chore: rename codecov to coverage

### DIFF
--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -2,7 +2,7 @@
 Authlib>=0.14.3
 black>=22.3.0
 bumpversion>=0.5
-codecov>=2.0.15
+coverage>=7.2.3
 flake8>=4.0.0
 parameterized>=0.7.0
 psycopg2-binary>=2.8.5


### PR DESCRIPTION
Renames a dependency that was deprecated. The new name is `coverage`.