### PR TITLE
fix: Modify CSP to Allow Hubspot

### DIFF
--- a/server/ecs/app.py
+++ b/server/ecs/app.py
@@ -66,10 +66,10 @@ class WSGIServer(Server):
         csp = {
             "default-src": ["'self'", HUBSPOT_FORMS_URL, HUBSPOT_JS_URL],
             "form-action": ["'self'", HUBSPOT_FORMS_URL],
-            "connect-src": ["'self'", PLAUSIBLE_URL] + extra_connect_src,
-            "script-src": ["'self'", "'unsafe-eval'", PLAUSIBLE_URL] + script_hashes,
+            "connect-src": ["'self'", PLAUSIBLE_URL, HUBSPOT_FORMS_URL] + extra_connect_src,
+            "script-src": ["'self'", "'unsafe-eval'", PLAUSIBLE_URL, HUBSPOT_FORMS_URL, HUBSPOT_JS_URL] + script_hashes,
             "style-src": ["'self'", "'unsafe-inline'"],
-            "img-src": ["'self'", "https://cellxgene.cziscience.com", "data:"],
+            "img-src": ["'self'", "https://cellxgene.cziscience.com", "data:", HUBSPOT_FORMS_URL],
             "object-src": ["'none'"],
             "base-uri": ["'none'"],
             "frame-ancestors": ["'none'"],


### PR DESCRIPTION
Cannot make a request to Hubspot

<img width="1440" alt="image" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/109984998/deddf94d-94ab-4b8f-a112-1d563703c716">

    
modifying headers to match GE: https://github.com/chanzuckerberg/single-cell-data-portal/pull/4679/files#diff-e064de65d4610383e665a32e7e32ee1f520c466a6a63ecea8925ff8337f08215:~:text=frontend/next.config.js

Continuation of this PR: https://github.com/chanzuckerberg/single-cell-explorer/pull/633