### PR TITLE
chore: decrease memory usage in staging explorer

### DIFF
--- a/.happy/terraform/envs/staging/main.tf
+++ b/.happy/terraform/envs/staging/main.tf
@@ -16,8 +16,8 @@ module stack {
   require_okta                 = false
   stack_prefix                 = "/${var.stack_name}"
   batch_container_memory_limit = 28000
-  memory                       = 50000
-  explorer_instance_count      = 2
+  memory                       = 14000
+  explorer_instance_count      = 1
 
 
   api_domain                   = "api.${local.domain}"


### PR DESCRIPTION
Decrease memory usage to 14G. This will allow running the explorer on an r5.large machine.