### PR TITLE
fix(explorer): filter out where feature_is_filtered is true

### DIFF
--- a/client/src/components/geneExpression/quickGene.tsx
+++ b/client/src/components/geneExpression/quickGene.tsx
@@ -61,6 +61,8 @@ function QuickGene() {
           const df: Dataframe = await annoMatrix.fetch("var", varIndex);
           let dfIds: Dataframe;
           const geneIdCol = "feature_id";
+          const isFilteredCol = "feature_is_filtered";
+          const isFiltered = await annoMatrix.fetch("var", isFilteredCol);
 
           // if feature id column is available in var
           if (annoMatrix.getMatrixColumns("var").includes(geneIdCol)) {
@@ -69,7 +71,16 @@ function QuickGene() {
           }
 
           setStatus("success");
-          setGeneNames(df.col(varIndex).asArray() as DataframeValue[]);
+
+          setGeneNames(
+            df
+              .col(varIndex)
+              .asArray()
+              .filter((geneName) => {
+                const index = df.col(varIndex).asArray().indexOf(geneName);
+                return !isFiltered.col(isFilteredCol).asArray()[index];
+              }) as DataframeValue[]
+          );
         } catch (error) {
           setStatus("error");
           throw error;
@@ -159,7 +170,6 @@ function QuickGene() {
       );
     });
   }, [userDefinedGenes, geneNames, geneIds, dispatch]);
-
   return (
     <div style={{ width: "100%", marginBottom: "16px" }}>
       <H4
@@ -197,7 +207,7 @@ function QuickGene() {
               inputProps={{
                 // @ts-expect-error ts-migrate(2322) FIXME: Type '{ "data-testid": string; placeholder: string... Remove this comment to see the full error message
                 "data-testid": "gene-search",
-                placeholder: "Quick Gene Search",
+                placeholder: "Quick Gene Search!",
                 leftIcon: IconNames.SEARCH,
                 fill: true,
               }}

--- a/client/src/components/geneExpression/quickGene.tsx
+++ b/client/src/components/geneExpression/quickGene.tsx
@@ -215,7 +215,7 @@ function QuickGene() {
               inputProps={{
                 // @ts-expect-error ts-migrate(2322) FIXME: Type '{ "data-testid": string; placeholder: string... Remove this comment to see the full error message
                 "data-testid": "gene-search",
-                placeholder: "Quick Gene Search!",
+                placeholder: "Quick Gene Search",
                 leftIcon: IconNames.SEARCH,
                 fill: true,
               }}

--- a/client/src/components/geneExpression/quickGene.tsx
+++ b/client/src/components/geneExpression/quickGene.tsx
@@ -75,16 +75,14 @@ function QuickGene() {
           setStatus("success");
 
           if (isFiltered) {
+            const isFilteredArray = isFiltered.col(isFilteredCol).asArray();
             setGeneNames(
               df
                 .col(varIndex)
                 .asArray()
-                .filter((_, index) => {
-                  const isFilteredValue = isFiltered
-                    .col(isFilteredCol)
-                    .asArray()[index];
-                  return !isFilteredValue;
-                }) as DataframeValue[]
+                .filter(
+                  (_, index) => !isFilteredArray[index] && _
+                ) as DataframeValue[]
             );
           } else {
             setGeneNames(df.col(varIndex).asArray() as DataframeValue[]);

--- a/client/src/components/geneExpression/quickGene.tsx
+++ b/client/src/components/geneExpression/quickGene.tsx
@@ -62,7 +62,9 @@ function QuickGene() {
           let dfIds: Dataframe;
           const geneIdCol = "feature_id";
           const isFilteredCol = "feature_is_filtered";
-          const isFiltered = await annoMatrix.fetch("var", isFilteredCol);
+          const isFiltered =
+            annoMatrix.getMatrixColumns("var").includes(isFilteredCol) &&
+            (await annoMatrix.fetch("var", isFilteredCol));
 
           // if feature id column is available in var
           if (annoMatrix.getMatrixColumns("var").includes(geneIdCol)) {
@@ -72,17 +74,21 @@ function QuickGene() {
 
           setStatus("success");
 
-          setGeneNames(
-            df
-              .col(varIndex)
-              .asArray()
-              .filter((_, index) => {
-                const isFilteredValue = isFiltered.col(isFilteredCol).asArray()[
-                  index
-                ];
-                return !isFilteredValue;
-              }) as DataframeValue[]
-          );
+          if (isFiltered) {
+            setGeneNames(
+              df
+                .col(varIndex)
+                .asArray()
+                .filter((_, index) => {
+                  const isFilteredValue = isFiltered
+                    .col(isFilteredCol)
+                    .asArray()[index];
+                  return !isFilteredValue;
+                }) as DataframeValue[]
+            );
+          } else {
+            setGeneNames(df.col(varIndex).asArray() as DataframeValue[]);
+          }
         } catch (error) {
           setStatus("error");
           throw error;

--- a/client/src/components/geneExpression/quickGene.tsx
+++ b/client/src/components/geneExpression/quickGene.tsx
@@ -76,9 +76,11 @@ function QuickGene() {
             df
               .col(varIndex)
               .asArray()
-              .filter((geneName) => {
-                const index = df.col(varIndex).asArray().indexOf(geneName);
-                return !isFiltered.col(isFilteredCol).asArray()[index];
+              .filter((_, index) => {
+                const isFilteredValue = isFiltered.col(isFilteredCol).asArray()[
+                  index
+                ];
+                return !isFilteredValue;
               }) as DataframeValue[]
           );
         } catch (error) {


### PR DESCRIPTION
#679 

Added logic to exclude genes where `feature_is_filtered:True` from the Quick Gene Search