### PR TITLE
feat: update breadcrumbs to be truncated to include Collection

### DIFF
--- a/client/src/components/datasetSelector/truncatingBreadcrumbs.tsx
+++ b/client/src/components/datasetSelector/truncatingBreadcrumbs.tsx
@@ -81,41 +81,25 @@ enum BreadcrumbState {
 /**
  * Breadcrumbs State
  * -----------------
- * FFF - full, full, full
- * FTF - full, truncated, full
- * HSF - hidden, short text, full
- * HST - hidden, short text, truncated
- * HHS - hidden, hidden, short text
- * HHH - hidden, hidden, hidden
+ * FF - full, full
+ * FT - full, truncated
+ * SS - short text, short text
+ * HH - hidden, hidden
  */
-type BreadcrumbsState = [BreadcrumbState, BreadcrumbState, BreadcrumbState];
-const STATES_FFF: BreadcrumbsState = [
-  BreadcrumbState.FULL,
+type BreadcrumbsState = [BreadcrumbState, BreadcrumbState];
+const STATES_FF: BreadcrumbsState = [
   BreadcrumbState.FULL,
   BreadcrumbState.FULL,
 ];
-const STATES_FTF: BreadcrumbsState = [
+const STATES_FT: BreadcrumbsState = [
   BreadcrumbState.FULL,
   BreadcrumbState.TRUNCATED,
-  BreadcrumbState.FULL,
 ];
-const STATES_HSF: BreadcrumbsState = [
-  BreadcrumbState.HIDDEN,
+const STATES_SS: BreadcrumbsState = [
   BreadcrumbState.SHORT_TEXT,
-  BreadcrumbState.FULL,
-];
-const STATES_HST: BreadcrumbsState = [
-  BreadcrumbState.HIDDEN,
-  BreadcrumbState.SHORT_TEXT,
-  BreadcrumbState.TRUNCATED,
-];
-const STATES_HHS: BreadcrumbsState = [
-  BreadcrumbState.HIDDEN,
-  BreadcrumbState.HIDDEN,
   BreadcrumbState.SHORT_TEXT,
 ];
-const STATES_HHH: BreadcrumbsState = [
-  BreadcrumbState.HIDDEN,
+const STATES_HH: BreadcrumbsState = [
   BreadcrumbState.HIDDEN,
   BreadcrumbState.HIDDEN,
 ];
@@ -126,12 +110,10 @@ const STATES_HHH: BreadcrumbsState = [
  * Breadcrumbs can transition bidirectionally through states in the following order, and can also repeat individual states.
  */
 const BreadcrumbsStateTransitions: BreadcrumbsState[] = [
-  STATES_FFF,
-  STATES_FTF,
-  STATES_HSF,
-  STATES_HST,
-  STATES_HHS,
-  STATES_HHH,
+  STATES_FF,
+  STATES_FT,
+  STATES_SS,
+  STATES_HH,
 ];
 
 /**


### PR DESCRIPTION
addresses this ticket: https://app.zenhub.com/workspaces/single-cell-5e2a191dad828d52cc78b028/issues/gh/chanzuckerberg/single-cell-explorer/599

none of the existing breadcrumb states would result in both the collection + dataset breadcrumbs using "short text". this PR fixes that by adding that as a state. additionally, since there's only two breadcrumbs, we only need to have two `BreadcrumbState`s in `BreadcrumbsState`.

i ran this locally and verified we showed "Collection > Dataset" if the screen was sufficiently small enough.

https://github.com/chanzuckerberg/single-cell-explorer/assets/5653616/b5649091-f2a4-4d8e-9b70-d18de322442c

note for posterity: in order to run this locally, i had to [mock the dataset-metadata endpoint](https://github.com/chanzuckerberg/single-cell-explorer/blob/main/dev_docs/developer_guidelines.md#mocking-the-dataset-metadata-endpoint) and comment out this block of code in `datasetSelector.tsx`:
```
  // Don't render if seamless features are not available.
  if (!seamlessEnabled) {
    return null;
  }
```