### PR TITLE
ci: correctly locate package-lock

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
-          cache-dependency-path: "package-lock.json"
+          cache-dependency-path: "client/package-lock.json"
       - name: Install dependencies
         run: |
           npm ci


### PR DESCRIPTION
Workflow wasn't finding the package-lock during the setup node step