### PR TITLE
chore: Update deploy GHA artifact upload paths

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: playwright-report
-          path: /Users/runner/work/single-cell-explorer/single-cell-explorer/client/playwright-report
+          path: playwright-report
           retention-days: 14
 
       - name: Upload blob report to GitHub Actions Artifacts
@@ -103,5 +103,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: all-blob-reports
-          path: /Users/runner/work/single-cell-explorer/single-cell-explorer/client/blob-report
+          path: blob-report
           retention-days: 1


### PR DESCRIPTION
Since the working directory is set to `/client`, I think we can eliminate `path: /Users/runner/work/single-cell-explorer/single-cell-explorer/client` part of the path? 

Hopefully this fixes the upload 🤞 