### PR TITLE
chore: Update e2e test timeout to prevent flaky tests

### DIFF
--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -76,7 +76,12 @@ export async function waitUntilNoSkeletonDetected(page: Page): Promise<void> {
         .all();
       expect(skeleton).toHaveLength(0);
     },
-    { page, timeoutMs: 10_000 }
+    { page,
+      /**
+       * (thuang): The diff exp test needs more retry, since the API call takes
+       * some time to complete.
+       */
+      maxRetry: 200}
   );
 }
 


### PR DESCRIPTION
It seems like updating the config to `maxRetry: 200` consistently pass all the tests. I'll merge it to `main` to see if it works in GHA lol