### PR TITLE
fix: fix regex API prefix substitution for dataset selection

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -46,7 +46,7 @@
     <script type="text/javascript">
       window.CELLXGENE = {};
       window.CELLXGENE.API = {
-        prefix: `http://localhost:<%= CXG_SERVER_PORT %>${location.pathname}/api/`,
+        prefix: `http://localhost:<%= CXG_SERVER_PORT %>${location.pathname.replace(/\/$/, "")}/api/`,
         version: "v0.3/",
       };
     </script>

--- a/client/index.html
+++ b/client/index.html
@@ -46,6 +46,9 @@
     <script type="text/javascript">
       window.CELLXGENE = {};
       window.CELLXGENE.API = {
+        // When there's a trailing slash on location.pathname, local e2e tests fail because
+        // they attempt to access http://localhost:3000//pbmc3k.cxg/api/ instead of 
+        // http://localhost:3000/pbmc3k.cxg/api/. This is a workaround for that issue.
         prefix: `http://localhost:<%= CXG_SERVER_PORT %>${location.pathname.replace(/\/$/, "")}/api/`,
         version: "v0.3/",
       };

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -27,6 +27,14 @@ export const QUERY_PARAM_EXPLAIN_NEW_TAB = "explainNewTab";
  * and ending with "api". This setup ensures it starts capturing at the single-character dataroot and includes any optional subpaths.
  */
 const REGEX_PATHNAME = /(?<=\/)[^/]{1}\/(?:[^/]+\/)*[^/]+\/(?=api)/;
+
+/**
+ * This regex is used to update the API prefix when the dataset selector is used.
+ * It matches the previous two segments (demarcated by `/`) leading up to `/api`.
+ * In deployed environments, these segments will be `s3_uri` and the S3 URI of the dataset.
+ * We require a separate REGEX because the dataset selector is applied to an API prefix that
+ * has already been updated with the S3 URI of the dataset.
+ */
 const REGEX_PATHNAME_FOR_DATASET_SELECTOR = /(?<=\/)\w+\/[^/]+\/(?=api)/;
 
 /* Config links types */

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -201,6 +201,7 @@ export function updateApiPrefix(): void {
   const pathname = location.pathname.substring(1);
   // For the API prefix in the format protocol/host/pathSegement/e/uuid.cxg, replace /e/uuid.cxg with the corresponding
   // path segments taken from the pathname.
+  console.log("DEBUG", API.prefix, pathname);
   API.prefix = API.prefix.replace(REGEX_PATHNAME, pathname);
 }
 
@@ -217,6 +218,7 @@ export function updateAPIWithS3(s3URI: S3URI): string {
   // must be double quoted so slashes are not decoded early by flask WSGI.
   const URISafeS3URI = encodeURIComponent(s3URI);
   const flaskSafeS3URI = `s3_uri/${encodeURIComponent(URISafeS3URI)}/`;
+  console.log("DEBUG", API.prefix, flaskSafeS3URI);
   API.prefix = API.prefix.replace(REGEX_PATHNAME, flaskSafeS3URI);
   return oldAPI;
 }

--- a/client/src/globals.ts
+++ b/client/src/globals.ts
@@ -27,6 +27,7 @@ export const QUERY_PARAM_EXPLAIN_NEW_TAB = "explainNewTab";
  * and ending with "api". This setup ensures it starts capturing at the single-character dataroot and includes any optional subpaths.
  */
 const REGEX_PATHNAME = /(?<=\/)[^/]{1}\/(?:[^/]+\/)*[^/]+\/(?=api)/;
+const REGEX_PATHNAME_FOR_DATASET_SELECTOR = /(?<=\/)\w+\/[^/]+\/(?=api)/;
 
 /* Config links types */
 export type ConfigLink = "about-dataset" | "collections-home-page";
@@ -201,8 +202,10 @@ export function updateApiPrefix(): void {
   const pathname = location.pathname.substring(1);
   // For the API prefix in the format protocol/host/pathSegement/e/uuid.cxg, replace /e/uuid.cxg with the corresponding
   // path segments taken from the pathname.
-  console.log("DEBUG", API.prefix, pathname);
-  API.prefix = API.prefix.replace(REGEX_PATHNAME, pathname);
+  API.prefix = API.prefix.replace(
+    REGEX_PATHNAME_FOR_DATASET_SELECTOR,
+    pathname
+  );
 }
 
 /**
@@ -218,7 +221,6 @@ export function updateAPIWithS3(s3URI: S3URI): string {
   // must be double quoted so slashes are not decoded early by flask WSGI.
   const URISafeS3URI = encodeURIComponent(s3URI);
   const flaskSafeS3URI = `s3_uri/${encodeURIComponent(URISafeS3URI)}/`;
-  console.log("DEBUG", API.prefix, flaskSafeS3URI);
   API.prefix = API.prefix.replace(REGEX_PATHNAME, flaskSafeS3URI);
   return oldAPI;
 }


### PR DESCRIPTION
 - Fixes an issue with the new REGEX not properly updating the API prefix when selecting a new dataset
 - Fixes an issue with trailing slashes when trying to access a CXG on localhost:3000 (this broke local e2e tests).

The "REGEX_PATHNAME_FOR_DATASET_SELECTOR" is what the original regex was prior to the changes made for enabling access to CXGs in S3 subfolders

Tested in a pirated `dev` deployment since we do not have test infrastructure for testing dataset selection.