### PR TITLE
fix(spatial): use global api prefix for /spatial/meta calls

### DIFF
--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -225,7 +225,7 @@ const doInitialDataLoad = (): ((
       datasetMetadataFetchAndLoad(dispatch, oldPrefix, config);
       // TODO: add logic to ensure this is working for spatial datasets when flag removed
       if (isSpatial) {
-        datasetSpatialMetadataFetchAndLoad(dispatch, oldPrefix);
+        datasetSpatialMetadataFetchAndLoad(dispatch);
       }
       const baseDataUrl = `${globals.API.prefix}${globals.API.version}`;
       const annoMatrix = new AnnoMatrixLoader(baseDataUrl, schema.schema);

--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -138,16 +138,14 @@ async function datasetMetadataFetchAndLoad(
 /**
  * Fetches and loads dataset spatial metadata.
  * @param dispatch - Function facilitating update of store.
- * @param oldPrefix - API prefix with dataset path that dataset metadata lives on. (Not S3 URI)
  */
 async function datasetSpatialMetadataFetchAndLoad(
-  dispatch: AppDispatch,
-  oldPrefix: string
+  dispatch: AppDispatch
 ): Promise<void> {
   try {
     const datasetSpatialMetadataResponse = await fetchJson<{
       metadata: DatasetSpatialMetadata;
-    }>("spatial/meta", oldPrefix);
+    }>("spatial/meta");
     dispatch({
       type: "request spatial metadata success",
       data: datasetSpatialMetadataResponse,


### PR DESCRIPTION
> So the /spatial/meta endpoint is 404'ing, but it’s 404'ing when trying to access via cellxgene/e/super-cool-spatial.cxg/api/v0.3/spatial/meta not cellxgene/s3_uri/s3%253A%252F%252Fhosted-cellxgene-dev%252Fsuper-cool-spatial.cxg/api/v0.3/spatial/meta