### PR TITLE
fix: missing uns array returns error instead of None

### DIFF
--- a/server/dataset/dataset.py
+++ b/server/dataset/dataset.py
@@ -433,9 +433,9 @@ class Dataset(metaclass=ABCMeta):
     def get_spatial(self):
         try:
             uns = self.open_array("uns")
-        except KeyError as e:
-            return e
-        metadata_dict = {}
-        for key in uns.meta:
-            metadata_dict[key] = uns.meta[key]
-        return metadata_dict
+            metadata_dict = {}
+            for key in uns.meta:
+                metadata_dict[key] = uns.meta[key]
+            return metadata_dict
+        except KeyError as _:
+            return None

--- a/server/dataset/dataset.py
+++ b/server/dataset/dataset.py
@@ -437,5 +437,5 @@ class Dataset(metaclass=ABCMeta):
             for key in uns.meta:
                 metadata_dict[key] = uns.meta[key]
             return metadata_dict
-        except KeyError as _:
+        except KeyError:
             return None


### PR DESCRIPTION
This is a fix for get_spatial() to return `None` instead of `e` when `uns` array is missing

Tests:
- Pulled same unaltered dataset from s3 (spatial without `uns`)
- Ran locally with spatial embedding

- Tested altered (spatial with `uns`)
- Ran locally with spatial embedding

<img width="1505" alt="Screenshot 2024-03-15 at 6 07 10 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/7976579/9b3b5317-2234-4226-a2b0-65af0c9bf639">
<img width="1507" alt="Screenshot 2024-03-15 at 6 07 28 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/7976579/01f17bc2-0f16-41dc-96da-15a2e7357f28">

