### PR TITLE
test: fix e2e test

### DIFF
--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -825,12 +825,21 @@ for (const option of options) {
     test("open gene info card and hide/remove", async ({ page }) => {
       await setup(option, page);
       await addGeneToSearch(geneToRequestInfo, page);
-      await requestGeneInfo(geneToRequestInfo, page);
-      await assertGeneInfoCardExists(geneToRequestInfo, page);
-      await minimizeGeneInfo(page);
-      await assertGeneInfoCardIsMinimized(geneToRequestInfo, page);
-      await removeGeneInfo(page);
-      await assertGeneInfoDoesNotExist(geneToRequestInfo, page);
+
+      await tryUntil(async () => {
+        await requestGeneInfo(geneToRequestInfo, page);
+        await assertGeneInfoCardExists(geneToRequestInfo, page);
+      }, { page });
+
+      await tryUntil(async () => {
+        await minimizeGeneInfo(page);
+        await assertGeneInfoCardIsMinimized(geneToRequestInfo, page);
+      }, { page });
+
+      await tryUntil(async () => {
+        await removeGeneInfo(page);
+        await assertGeneInfoDoesNotExist(geneToRequestInfo, page);
+      }, { page });
     });
   });
 }


### PR DESCRIPTION
`open gene info card and hide/remove` seems to still be flaky because the click on minimize geneInfo card wasn't registered. So I've added tryUntil around the action and assertion pair for each test step!