### PR TITLE
fix: fix lasso canceling by removing definition checking

### DIFF
--- a/client/src/components/graph/setupLasso.ts
+++ b/client/src/components/graph/setupLasso.ts
@@ -96,9 +96,9 @@ const Lasso = () => {
     };
 
     const handleCancel = () => {
-      if (!(lassoPath && closePath && lassoPolygon)) return;
+      if (!(lassoPath && lassoPolygon)) return;
       lassoPath.remove();
-      closePath = closePath?.remove();
+      if (closePath) closePath = closePath?.remove();
       lassoPath = null;
       lassoPolygon = null;
       closePath = null;


### PR DESCRIPTION
#843 

Lasso wasn't cancelling correctly because the function was always expecting the close path to be defined, even thought it almost never is.