### PR TITLE
test: Add chromatic screenshots for all tests

### DIFF
--- a/.github/workflows/deploy-happy-stack.yml
+++ b/.github/workflows/deploy-happy-stack.yml
@@ -55,7 +55,8 @@ jobs:
           env-file: /home/runner/work/custom/envfile
           happy_version: "0.79.1"
   smoke-test:
-    timeout-minutes: 25
+    # (thuang): We now run the smoke tests against 2 datasets sequentially, so need longer timeout
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     needs:
       - upgrade

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -82,7 +82,8 @@ jobs:
 
   smoke-tests:
     runs-on: ubuntu-22.04
-    timeout-minutes: 25
+    # (thuang): We now run the smoke tests against 2 datasets sequentially, so need longer timeout
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -532,15 +532,18 @@ export async function assertGeneInfoCardIsMinimized(
     "clear-gene-info",
   ];
 
-  await tryUntil(async () => {
-    for (const id of testIds) {
-      const result = await page.getByTestId(id).isVisible();
-      await expect(result).toBe(true);
-    }
+  await tryUntil(
+    async () => {
+      for (const id of testIds) {
+        const result = await page.getByTestId(id).isVisible();
+        await expect(result).toBe(true);
+      }
 
-    const result = await page.getByTestId("gene-info-symbol").isVisible();
-    await expect(result).toBe(false);
-  }, {page});
+      const result = await page.getByTestId("gene-info-symbol").isVisible();
+      await expect(result).toBe(false);
+    },
+    { page }
+  );
 }
 
 export async function removeGeneInfo(page: Page): Promise<void> {
@@ -557,12 +560,15 @@ export async function assertGeneInfoDoesNotExist(
     "min-gene-info",
     "clear-gene-info",
   ];
-  await tryUntil(async () => {
-    for (const id of testIds) {
-      const result = await page.getByTestId(id).isVisible();
-      await expect(result).toBe(false);
-    }
-  }, {page});
+  await tryUntil(
+    async () => {
+      for (const id of testIds) {
+        const result = await page.getByTestId(id).isVisible();
+        await expect(result).toBe(false);
+      }
+    },
+    { page }
+  );
 }
 
 /**
@@ -675,9 +681,17 @@ export async function assertUndoRedo(
 export async function snapshotTestGraph(page: Page, testInfo: TestInfo) {
   const buttonID = "capture-and-display-graph";
   const imageID = "graph-image";
-  await page.getByTestId(buttonID).click();
-  page.getByTestId(imageID).waitFor();
-  await takeSnapshot(page, testInfo);
+
+  await tryUntil(
+    async () => {
+      await page.getByTestId(buttonID).click({ force: true });
+
+      page.getByTestId(imageID).waitFor();
+
+      await takeSnapshot(page, testInfo);
+    },
+    { page }
+  );
 }
 
 /* eslint-enable no-await-in-loop -- await in loop is needed to emulate sequential user actions */

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -686,7 +686,7 @@ export async function snapshotTestGraph(page: Page, testInfo: TestInfo) {
     async () => {
       await page.getByTestId(buttonID).click({ force: true });
 
-      page.getByTestId(imageID).waitFor();
+      await page.getByTestId(imageID).waitFor();
 
       await takeSnapshot(page, testInfo);
     },

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -367,8 +367,15 @@ export async function editGenesetName(
 ): Promise<void> {
   const editButton = `${genesetName}:edit-genesetName-mode`;
   const submitButton = `${genesetName}:submit-geneset`;
-  await page.getByTestId(`${genesetName}:see-actions`).click();
-  await page.getByTestId(editButton).click({ force: true });
+
+  await tryUntil(
+    async () => {
+      await page.getByTestId(`${genesetName}:see-actions`).click();
+      await page.getByTestId(editButton).click({ force: true });
+    },
+    { page }
+  );
+
   await tryUntil(
     async () => {
       await page.getByTestId("rename-geneset-modal").fill(editText);
@@ -406,10 +413,17 @@ export async function deleteGeneset(
   page: Page
 ): Promise<void> {
   const targetId = `${genesetName}:delete-geneset`;
-  await page.getByTestId(`${genesetName}:see-actions`).click({ force: true });
-  await page.getByTestId(targetId).click({ force: true });
+  await tryUntil(
+    async () => {
+      await page
+        .getByTestId(`${genesetName}:see-actions`)
+        .click({ force: true });
+      await page.getByTestId(targetId).click({ force: true });
 
-  await assertGenesetDoesNotExist(genesetName, page);
+      await assertGenesetDoesNotExist(genesetName, page);
+    },
+    { page }
+  );
 }
 
 export async function assertGenesetDoesNotExist(

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -384,11 +384,21 @@ export async function checkGenesetDescription(
   descriptionText: string,
   page: Page
 ): Promise<void> {
-  const editButton = `${genesetName}:edit-genesetName-mode`;
-  await page.getByTestId(`${genesetName}:see-actions`).click({ force: true });
-  await page.getByTestId(editButton).click({ force: true });
-  const description = page.getByTestId("change-geneset-description");
-  await expect(description).toHaveValue(descriptionText);
+  await tryUntil(
+    async () => {
+      await page
+        .getByTestId(`${genesetName}:see-actions`)
+        .click({ force: true });
+
+      const editButton = `${genesetName}:edit-genesetName-mode`;
+      await page.getByTestId(editButton).click({ force: true });
+
+      const description = page.getByTestId("change-geneset-description");
+
+      await expect(description).toHaveValue(descriptionText);
+    },
+    { page }
+  );
 }
 
 export async function deleteGeneset(

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -371,7 +371,13 @@ export async function editGenesetName(
   await tryUntil(
     async () => {
       await page.getByTestId(`${genesetName}:see-actions`).click();
-      await page.getByTestId(editButton).click({ force: true });
+      await page.getByTestId(editButton).click({
+        force: true,
+        /**
+         * (thuang): Don't wait for the default timeout, since we want to fail fast
+         */
+        timeout: 1 * 1000,
+      });
     },
     { page }
   );
@@ -398,7 +404,13 @@ export async function checkGenesetDescription(
         .click({ force: true });
 
       const editButton = `${genesetName}:edit-genesetName-mode`;
-      await page.getByTestId(editButton).click({ force: true });
+      await page.getByTestId(editButton).click({
+        force: true
+        /**
+         * (thuang): Don't wait for the default timeout, since we want to fail fast
+         */,
+        timeout: 1 * 1000,
+      });
 
       const description = page.getByTestId("change-geneset-description");
 
@@ -418,7 +430,13 @@ export async function deleteGeneset(
       await page
         .getByTestId(`${genesetName}:see-actions`)
         .click({ force: true });
-      await page.getByTestId(targetId).click({ force: true });
+
+      await page.getByTestId(targetId).click({
+        force: true,
+        /**
+         * (thuang): Don't wait for the default timeout, since we want to fail fast
+         */ timeout: 1 * 1000,
+      });
 
       await assertGenesetDoesNotExist(genesetName, page);
     },

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -730,9 +730,7 @@ for (const testDataset of testDatasets) {
           await snapshotTestGraph(page, testInfo);
         });
 
-        test("create a new geneset and undo/redo", async ({
-          page,
-        }, testInfo) => {
+        test("create a new geneset and undo/redo", async ({ page }) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -748,27 +746,21 @@ for (const testDataset of testDatasets) {
 
               await assertGenesetDoesNotExist(genesetName, page);
 
-              await snapshotTestGraph(page, testInfo);
-
               await createGeneset(genesetName, page);
 
               await assertGenesetExists(genesetName, page);
 
-              await snapshotTestGraph(page, testInfo);
-
               await assertUndoRedo(
                 page,
-                async () => assertGenesetDoesNotExist(genesetName, page),
-                async () => assertGenesetExists(genesetName, page)
+                () => assertGenesetDoesNotExist(genesetName, page),
+                () => assertGenesetExists(genesetName, page)
               );
-
-              await snapshotTestGraph(page, testInfo);
             },
             { page }
           );
         });
 
-        test("edit geneset name and undo/redo", async ({ page }, testInfo) => {
+        test("edit geneset name and undo/redo", async ({ page }) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -780,19 +772,17 @@ for (const testDataset of testDatasets) {
 
               await assertGenesetExists(newGenesetName, page);
 
-              await snapshotTestGraph(page, testInfo);
-
               await assertUndoRedo(
                 page,
-                async () => assertGenesetExists(editableGenesetName, page),
-                async () => assertGenesetExists(newGenesetName, page)
+                () => assertGenesetExists(editableGenesetName, page),
+                () => assertGenesetExists(newGenesetName, page)
               );
             },
             { page }
           );
         });
 
-        test("delete a geneset and undo/redo", async ({ page }, testInfo) => {
+        test("delete a geneset and undo/redo", async ({ page }) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -802,23 +792,15 @@ for (const testDataset of testDatasets) {
 
               await setup({ option, page, url });
 
-              await snapshotTestGraph(page, testInfo);
-
               await createGeneset(genesetToDeleteName, page);
-
-              await snapshotTestGraph(page, testInfo);
 
               await deleteGeneset(genesetToDeleteName, page);
 
-              await snapshotTestGraph(page, testInfo);
-
               await assertUndoRedo(
                 page,
-                async () => assertGenesetExists(genesetToDeleteName, page),
-                async () => assertGenesetDoesNotExist(genesetToDeleteName, page)
+                () => assertGenesetExists(genesetToDeleteName, page),
+                () => assertGenesetDoesNotExist(genesetToDeleteName, page)
               );
-
-              await snapshotTestGraph(page, testInfo);
             },
             { page }
           );
@@ -844,9 +826,7 @@ for (const testDataset of testDatasets) {
       });
 
       describe(`GENE crud operations and interactions ${option.tag}`, () => {
-        test("add a gene to geneset and undo/redo", async ({
-          page,
-        }, testInfo) => {
+        test("add a gene to geneset and undo/redo", async ({ page }) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -857,15 +837,11 @@ for (const testDataset of testDatasets) {
               await addGeneToSetAndExpand(setToAddGeneTo, geneToAddToSet, page);
               await assertGeneExistsInGeneset(geneToAddToSet, page);
 
-              await snapshotTestGraph(page, testInfo);
-
               await assertUndoRedo(
                 page,
-                async () => assertGeneDoesNotExist(geneToAddToSet, page),
-                async () => assertGeneExistsInGeneset(geneToAddToSet, page)
+                () => assertGeneDoesNotExist(geneToAddToSet, page),
+                () => assertGeneExistsInGeneset(geneToAddToSet, page)
               );
-
-              await snapshotTestGraph(page, testInfo);
             },
             { page }
           );
@@ -925,9 +901,7 @@ for (const testDataset of testDatasets) {
           await assertColorLegendLabel("SIK1", page);
           await snapshotTestGraph(page, testInfo);
         });
-        test("delete gene from geneset and undo/redo", async ({
-          page,
-        }, testInfo) => {
+        test("delete gene from geneset and undo/redo", async ({ page }) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -939,21 +913,15 @@ for (const testDataset of testDatasets) {
               await createGeneset(setToRemoveFrom, page);
               await addGeneToSetAndExpand(setToRemoveFrom, geneToRemove, page);
 
-              await snapshotTestGraph(page, testInfo);
-
               await removeGene(geneToRemove, page);
 
               await assertGeneDoesNotExist(geneToRemove, page);
 
-              await snapshotTestGraph(page, testInfo);
-
               await assertUndoRedo(
                 page,
-                async () => assertGeneExistsInGeneset(geneToRemove, page),
-                async () => assertGeneDoesNotExist(geneToRemove, page)
+                () => assertGeneExistsInGeneset(geneToRemove, page),
+                () => assertGeneDoesNotExist(geneToRemove, page)
               );
-
-              await snapshotTestGraph(page, testInfo);
             },
             { page }
           );

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -107,43 +107,53 @@ for (const testDataset of testDatasets) {
 
   describe(`dataset: ${testDataset}`, () => {
     describe("did launch", () => {
-      test("page launched", async ({ page }) => {
+      test("page launched", async ({ page }, testInfo) => {
         await goToPage(page, url);
 
         const element = await page.getByTestId("header").innerHTML();
 
         expect(element).toMatchSnapshot();
+
+        await snapshotTestGraph(page, testInfo);
       });
     });
 
     describe("breadcrumbs loads", () => {
       test("dataset and collection from breadcrumbs appears", async ({
         page,
-      }) => {
+      }, testInfo) => {
         await goToPage(page, url);
 
         const datasetElement = await page.getByTestId("bc-Dataset").innerHTML();
         const collectionsElement = await page
           .getByTestId("bc-Collection")
           .innerHTML();
+
         expect(datasetElement).toMatchSnapshot();
         expect(collectionsElement).toMatchSnapshot();
+
+        await snapshotTestGraph(page, testInfo);
       });
 
       test("datasets from breadcrumbs appears on clicking collections", async ({
         page,
       }) => {
         await goToPage(page, url);
+
         await page.getByTestId(`bc-Dataset`).click();
+
         const element = await page
           .getByTestId("dataset-menu-item-Sed eu nisi condimentum")
           .innerHTML();
+
         expect(element).toMatchSnapshot();
       });
     });
 
     describe("metadata loads", () => {
-      test("categories and values from dataset appear", async ({ page }) => {
+      test("categories and values from dataset appear", async ({
+        page,
+      }, testInfo) => {
         await goToPage(page, url);
         for (const label of Object.keys(
           data.categorical
@@ -159,33 +169,42 @@ for (const testDataset of testDatasets) {
           const categories = await getAllCategoriesAndCounts(label, page);
 
           expect(categories).toMatchObject(data.categorical[label]);
+
+          await snapshotTestGraph(page, testInfo);
         }
       });
 
-      test("continuous data appears", async ({ page }) => {
+      test("continuous data appears", async ({ page }, testInfo) => {
         await goToPage(page, url);
         for (const label of Object.keys(data.continuous)) {
           expect(
             await page.getByTestId(`histogram-${label}-plot`)
           ).not.toHaveCount(0);
+
+          await snapshotTestGraph(page, testInfo);
         }
       });
     });
 
     describe("cell selection", () => {
-      test("selects all cells cellset 1", async ({ page }) => {
+      test("selects all cells cellset 1", async ({ page }, testInfo) => {
         await goToPage(page, url);
         const cellCount = await getCellSetCount(1, page);
+
         expect(cellCount).toBe(data.dataframe.nObs);
+        await snapshotTestGraph(page, testInfo);
       });
 
-      test("selects all cells cellset 2", async ({ page }) => {
+      test("selects all cells cellset 2", async ({ page }, testInfo) => {
         await goToPage(page, url);
         const cellCount = await getCellSetCount(2, page);
+
         expect(cellCount).toBe(data.dataframe.nObs);
+
+        await snapshotTestGraph(page, testInfo);
       });
 
-      test("selects cells via lasso", async ({ page }) => {
+      test("selects cells via lasso", async ({ page }, testInfo) => {
         await goToPage(page, url);
         for (const cellset of data.cellsets.lasso) {
           const cellset1 = await calcDragCoordinates(
@@ -195,13 +214,17 @@ for (const testDataset of testDatasets) {
           );
 
           await drag("layout-graph", cellset1.start, cellset1.end, page, true);
+
           const cellCount = await getCellSetCount(1, page);
+
           expect(cellCount).toBe(cellset.count);
+          await snapshotTestGraph(page, testInfo);
         }
       });
 
-      test("selects cells via categorical", async ({ page }) => {
+      test("selects cells via categorical", async ({ page }, testInfo) => {
         await goToPage(page, url);
+
         for (const cellset of data.cellsets.categorical) {
           await page.getByTestId(`${cellset.metadata}:category-expand`).click();
           await page
@@ -219,10 +242,12 @@ for (const testDataset of testDatasets) {
           const cellCount = await getCellSetCount(1, page);
 
           expect(cellCount).toBe(cellset.count);
+
+          await snapshotTestGraph(page, testInfo);
         }
       });
 
-      test("selects cells via continuous", async ({ page }) => {
+      test("selects cells via continuous", async ({ page }, testInfo) => {
         await goToPage(page, url);
         for (const cellset of data.cellsets.continuous) {
           const histBrushableAreaId = `histogram-${cellset.metadata}-plot-brushable-area`;
@@ -238,12 +263,14 @@ for (const testDataset of testDatasets) {
           const cellCount = await getCellSetCount(1, page);
 
           expect(cellCount).toBe(cellset.count);
+
+          await snapshotTestGraph(page, testInfo);
         }
       });
     });
 
     describe("subset", () => {
-      test("subset - cell count matches", async ({ page }) => {
+      test("subset - cell count matches", async ({ page }, testInfo) => {
         await goToPage(page, url);
         for (const select of data.subset.cellset1) {
           if (select.kind === "categorical") {
@@ -259,10 +286,12 @@ for (const testDataset of testDatasets) {
           const categories = await getAllCategoriesAndCounts(label, page);
 
           expect(categories).toMatchObject(data.subset.categorical[label]);
+
+          await snapshotTestGraph(page, testInfo);
         }
       });
 
-      test("lasso after subset", async ({ page }) => {
+      test("lasso after subset", async ({ page }, testInfo) => {
         await goToPage(page, url);
         for (const select of data.subset.cellset1) {
           if (select.kind === "categorical") {
@@ -287,12 +316,14 @@ for (const testDataset of testDatasets) {
         );
 
         const cellCount = await getCellSetCount(1, page);
+
         expect(cellCount).toBe(data.subset.lasso.count);
+        await snapshotTestGraph(page, testInfo);
       });
     });
 
     describe("clipping", () => {
-      test("clip continuous", async ({ page }) => {
+      test("clip continuous", async ({ page }, testInfo) => {
         await goToPage(page, url);
         await clip(data.clip.min, data.clip.max, page);
         const histBrushableAreaId = `histogram-${data.clip.metadata}-plot-brushable-area`;
@@ -320,6 +351,8 @@ for (const testDataset of testDatasets) {
           const categories = await getAllCategoriesAndCounts(label, page);
 
           expect(categories).toMatchObject(data.categorical[label]);
+
+          await snapshotTestGraph(page, testInfo);
         }
       });
     });
@@ -356,7 +389,7 @@ for (const testDataset of testDatasets) {
     });
 
     describe("centroid labels", () => {
-      test("labels are created", async ({ page }) => {
+      test("labels are created", async ({ page }, testInfo) => {
         await goToPage(page, url);
         const labels = Object.keys(
           data.categorical
@@ -378,12 +411,14 @@ for (const testDataset of testDatasets) {
           expect(generatedLabels).toHaveLength(
             Object.keys(data.categorical[label]).length
           );
+
+          await snapshotTestGraph(page, testInfo);
         }
       });
     });
 
     describe("graph overlay", () => {
-      test("transform centroids correctly", async ({ page }) => {
+      test("transform centroids correctly", async ({ page }, testInfo) => {
         await goToPage(page, url);
         const category = Object.keys(
           data.categorical
@@ -425,10 +460,12 @@ for (const testDataset of testDatasets) {
           },
           { page }
         );
+
+        await snapshotTestGraph(page, testInfo);
       });
     });
 
-    test("zoom limit is 12x", async ({ page }) => {
+    test("zoom limit is 12x", async ({ page }, testInfo) => {
       await goToPage(page, url);
       const category = Object.keys(
         data.categorical
@@ -461,9 +498,11 @@ for (const testDataset of testDatasets) {
         },
         { page }
       );
+
+      await snapshotTestGraph(page, testInfo);
     });
 
-    test("pan zoom mode resets lasso selection", async ({ page }) => {
+    test("pan zoom mode resets lasso selection", async ({ page }, testInfo) => {
       await goToPage(page, url);
 
       await tryUntil(
@@ -498,9 +537,11 @@ for (const testDataset of testDatasets) {
         },
         { page }
       );
+
+      await snapshotTestGraph(page, testInfo);
     });
 
-    test("lasso moves after pan", async ({ page }) => {
+    test("lasso moves after pan", async ({ page }, testInfo) => {
       goToPage(page, url);
 
       await tryUntil(
@@ -514,6 +555,8 @@ for (const testDataset of testDatasets) {
             page
           );
 
+          await snapshotTestGraph(page, testInfo);
+
           await drag(
             "layout-graph",
             lassoSelection.start,
@@ -521,6 +564,8 @@ for (const testDataset of testDatasets) {
             page,
             true
           );
+
+          await snapshotTestGraph(page, testInfo);
 
           await expect(page.getByTestId("lasso-element")).toBeVisible();
 
@@ -530,6 +575,8 @@ for (const testDataset of testDatasets) {
 
           await page.getByTestId("mode-pan-zoom").click();
 
+          await snapshotTestGraph(page, testInfo);
+
           const panCoords = await calcDragCoordinates(
             "layout-graph",
             coordinatesAsPercent,
@@ -537,11 +584,16 @@ for (const testDataset of testDatasets) {
           );
 
           await drag("layout-graph", panCoords.start, panCoords.end, page);
+
+          await snapshotTestGraph(page, testInfo);
+
           await page.getByTestId("mode-lasso").click();
 
           const panCount = await getCellSetCount(2, page);
 
           expect(panCount).toBe(initialCount);
+
+          await snapshotTestGraph(page, testInfo);
         },
         { page }
       );
@@ -558,7 +610,7 @@ for (const testDataset of testDatasets) {
 
     for (const option of options) {
       describe(`geneSET crud operations and interactions ${option.tag}`, () => {
-        test("brush on geneset mean", async ({ page }) => {
+        test("brush on geneset mean", async ({ page }, testInfo) => {
           await setup({ option, page, url });
           await createGeneset(meanExpressionBrushGenesetName, page);
           await addGeneToSetAndExpand(
@@ -579,6 +631,7 @@ for (const testDataset of testDatasets) {
             },
             page
           );
+
           await drag(histBrushableAreaId, coords.start, coords.end, page);
           await page.getByTestId(`cellset-button-1`).click();
           const cellCount = await getCellSetCount(1, page);
@@ -586,8 +639,10 @@ for (const testDataset of testDatasets) {
           // (seve): the withSubset version of this test is resulting in the unsubsetted value
           if (option.withSubset) {
             expect(cellCount).toBe(data.brushOnGenesetMean.withSubset);
+            await snapshotTestGraph(page, testInfo);
           } else {
             expect(cellCount).toBe(data.brushOnGenesetMean.default);
+            await snapshotTestGraph(page, testInfo);
           }
         });
 
@@ -605,7 +660,7 @@ for (const testDataset of testDatasets) {
           await snapshotTestGraph(page, testInfo);
         });
 
-        test("diffexp", async ({ page }) => {
+        test("diffexp", async ({ page }, testInfo) => {
           if (option.withSubset) return;
 
           const runningAgainstDeployment = !testURL.includes("localhost");
@@ -649,6 +704,7 @@ for (const testDataset of testDatasets) {
           let genesHTML = await page.getByTestId("gene-set-genes").innerHTML();
 
           expect(genesHTML).toMatchSnapshot();
+          await snapshotTestGraph(page, testInfo);
 
           // (thuang): We need to assert Pop2 geneset is expanded, because sometimes
           // the click is so fast that it's not registered
@@ -671,9 +727,12 @@ for (const testDataset of testDatasets) {
           genesHTML = await page.getByTestId("gene-set-genes").innerHTML();
 
           expect(genesHTML).toMatchSnapshot();
+          await snapshotTestGraph(page, testInfo);
         });
 
-        test("create a new geneset and undo/redo", async ({ page }) => {
+        test("create a new geneset and undo/redo", async ({
+          page,
+        }, testInfo) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -686,20 +745,30 @@ for (const testDataset of testDatasets) {
               waitUntilNoSkeletonDetected(page);
 
               const genesetName = `test-geneset-foo-123`;
+
               await assertGenesetDoesNotExist(genesetName, page);
+
+              await snapshotTestGraph(page, testInfo);
+
               await createGeneset(genesetName, page);
+
               await assertGenesetExists(genesetName, page);
+
+              await snapshotTestGraph(page, testInfo);
+
               await assertUndoRedo(
                 page,
                 async () => assertGenesetDoesNotExist(genesetName, page),
                 async () => assertGenesetExists(genesetName, page)
               );
+
+              await snapshotTestGraph(page, testInfo);
             },
             { page }
           );
         });
 
-        test("edit geneset name and undo/redo", async ({ page }) => {
+        test("edit geneset name and undo/redo", async ({ page }, testInfo) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -708,7 +777,11 @@ for (const testDataset of testDatasets) {
               await setup({ option, page, url });
               await createGeneset(editableGenesetName, page);
               await editGenesetName(editableGenesetName, newGenesetName, page);
+
               await assertGenesetExists(newGenesetName, page);
+
+              await snapshotTestGraph(page, testInfo);
+
               await assertUndoRedo(
                 page,
                 async () => assertGenesetExists(editableGenesetName, page),
@@ -719,7 +792,7 @@ for (const testDataset of testDatasets) {
           );
         });
 
-        test("delete a geneset and undo/redo", async ({ page }) => {
+        test("delete a geneset and undo/redo", async ({ page }, testInfo) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -728,13 +801,24 @@ for (const testDataset of testDatasets) {
               if (option.withSubset) return;
 
               await setup({ option, page, url });
+
+              await snapshotTestGraph(page, testInfo);
+
               await createGeneset(genesetToDeleteName, page);
+
+              await snapshotTestGraph(page, testInfo);
+
               await deleteGeneset(genesetToDeleteName, page);
+
+              await snapshotTestGraph(page, testInfo);
+
               await assertUndoRedo(
                 page,
                 async () => assertGenesetExists(genesetToDeleteName, page),
                 async () => assertGenesetDoesNotExist(genesetToDeleteName, page)
               );
+
+              await snapshotTestGraph(page, testInfo);
             },
             { page }
           );
@@ -744,11 +828,13 @@ for (const testDataset of testDatasets) {
           if (option.withSubset) return;
 
           await setup({ option, page, url });
+
           await createGeneset(
             genesetToCheckForDescription,
             page,
             genesetDescriptionString
           );
+
           await checkGenesetDescription(
             genesetToCheckForDescription,
             genesetDescriptionString,
@@ -758,7 +844,9 @@ for (const testDataset of testDatasets) {
       });
 
       describe(`GENE crud operations and interactions ${option.tag}`, () => {
-        test("add a gene to geneset and undo/redo", async ({ page }) => {
+        test("add a gene to geneset and undo/redo", async ({
+          page,
+        }, testInfo) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -768,16 +856,22 @@ for (const testDataset of testDatasets) {
               await createGeneset(setToAddGeneTo, page);
               await addGeneToSetAndExpand(setToAddGeneTo, geneToAddToSet, page);
               await assertGeneExistsInGeneset(geneToAddToSet, page);
+
+              await snapshotTestGraph(page, testInfo);
+
               await assertUndoRedo(
                 page,
                 async () => assertGeneDoesNotExist(geneToAddToSet, page),
                 async () => assertGeneExistsInGeneset(geneToAddToSet, page)
               );
+
+              await snapshotTestGraph(page, testInfo);
             },
             { page }
           );
         });
-        test("expand gene and brush", async ({ page }) => {
+
+        test("expand gene and brush", async ({ page }, testInfo) => {
           await setup({ option, page, url });
           await createGeneset(brushThisGeneGeneset, page);
           await addGeneToSetAndExpand(
@@ -798,17 +892,29 @@ for (const testDataset of testDatasets) {
             },
             page
           );
+
+          await snapshotTestGraph(page, testInfo);
+
           await drag(histBrushableAreaId, coords.start, coords.end, page);
+
+          await snapshotTestGraph(page, testInfo);
+
           const cellCount = await getCellSetCount(1, page);
+
           if (option.withSubset) {
             expect(cellCount).toBe(data.expandGeneAndBrush.withSubset);
+            await snapshotTestGraph(page, testInfo);
           } else {
             expect(cellCount).toBe(data.expandGeneAndBrush.default);
+            await snapshotTestGraph(page, testInfo);
           }
         });
-        test("color by gene in geneset", async ({ page }) => {
+
+        test("color by gene in geneset", async ({ page }, testInfo) => {
           await setup({ option, page, url });
+
           await createGeneset(meanExpressionBrushGenesetName, page);
+
           await addGeneToSetAndExpand(
             meanExpressionBrushGenesetName,
             "SIK1",
@@ -817,8 +923,11 @@ for (const testDataset of testDatasets) {
 
           await colorByGene("SIK1", page);
           await assertColorLegendLabel("SIK1", page);
+          await snapshotTestGraph(page, testInfo);
         });
-        test("delete gene from geneset and undo/redo", async ({ page }) => {
+        test("delete gene from geneset and undo/redo", async ({
+          page,
+        }, testInfo) => {
           /**
            * (thuang): Test is flaky, so we need to retry until it passes
            */
@@ -829,20 +938,34 @@ for (const testDataset of testDatasets) {
               await setup({ option, page, url });
               await createGeneset(setToRemoveFrom, page);
               await addGeneToSetAndExpand(setToRemoveFrom, geneToRemove, page);
+
+              await snapshotTestGraph(page, testInfo);
+
               await removeGene(geneToRemove, page);
+
               await assertGeneDoesNotExist(geneToRemove, page);
+
+              await snapshotTestGraph(page, testInfo);
+
               await assertUndoRedo(
                 page,
                 async () => assertGeneExistsInGeneset(geneToRemove, page),
                 async () => assertGeneDoesNotExist(geneToRemove, page)
               );
+
+              await snapshotTestGraph(page, testInfo);
             },
             { page }
           );
         });
-        test("open gene info card and hide/remove", async ({ page }) => {
+
+        test("open gene info card and hide/remove", async ({
+          page,
+        }, testInfo) => {
           await setup({ option, page, url });
           await addGeneToSearch(geneToRequestInfo, page);
+
+          await snapshotTestGraph(page, testInfo);
 
           await tryUntil(
             async () => {
@@ -852,6 +975,8 @@ for (const testDataset of testDatasets) {
             { page }
           );
 
+          await snapshotTestGraph(page, testInfo);
+
           await tryUntil(
             async () => {
               await minimizeGeneInfo(page);
@@ -860,6 +985,8 @@ for (const testDataset of testDatasets) {
             { page }
           );
 
+          await snapshotTestGraph(page, testInfo);
+
           await tryUntil(
             async () => {
               await removeGeneInfo(page);
@@ -867,6 +994,8 @@ for (const testDataset of testDatasets) {
             },
             { page }
           );
+
+          await snapshotTestGraph(page, testInfo);
         });
       });
     }
@@ -875,8 +1004,9 @@ for (const testDataset of testDatasets) {
 
 test("categories and values from dataset appear and properly truncate if applicable", async ({
   page,
-}) => {
+}, testInfo) => {
   await goToPage(page, pageURLTruncate);
+
   await tryUntil(
     async () => {
       await page.getByTestId(`truncate:category-expand`).click();
@@ -886,6 +1016,7 @@ test("categories and values from dataset appear and properly truncate if applica
         .all();
 
       expect(Object.keys(categoryRows).length).toBe(1001);
+      await snapshotTestGraph(page, testInfo);
     },
     { page }
   );

--- a/client/configuration/lint-staged/lint-staged.config.js
+++ b/client/configuration/lint-staged/lint-staged.config.js
@@ -1,4 +1,8 @@
 module.exports = {
-  "*.{js,ts,jsx,tsx}": [() => "tsc --project tsconfig.json", "eslint --fix"],
+  "*.{js,ts,jsx,tsx}": [
+    // (thuang): Run tsc against the whole project, so we get all the type information
+    () => "tsc --project tsconfig.json",
+    "eslint --fix",
+  ],
   "src/**/*": "prettier --write --ignore-unknown",
 };

--- a/client/src/components/menubar/index.tsx
+++ b/client/src/components/menubar/index.tsx
@@ -374,23 +374,18 @@ class MenuBar extends React.PureComponent<{}, State> {
             </Tooltip>
           )}
           {isTest && (
-            <Tooltip
-              content="🌊"
-              position="bottom"
-              hoverOpenDelay={globals.tooltipHoverOpenDelay}
-            >
-              <AnchorButton
-                className={styles.menubarButton}
-                type="button"
-                icon={IconNames.TORCH}
-                style={{
-                  cursor: "pointer",
-                }}
-                data-testid="capture-and-display-graph"
-                loading={screenCap}
-                onClick={() => dispatch({ type: "test: screencap start" })}
-              />
-            </Tooltip>
+            <AnchorButton
+              className={styles.menubarButton}
+              type="button"
+              icon={IconNames.TORCH}
+              style={{
+                cursor: "pointer",
+              }}
+              data-testid="capture-and-display-graph"
+              data-chromatic="ignore"
+              loading={screenCap}
+              onClick={() => dispatch({ type: "test: screencap start" })}
+            />
           )}
           <Clip
             // @ts-expect-error ts-migrate(2322) FIXME: Type '{ pendingClipPercentiles: any; clipPercentil... Remove this comment to see the full error message

--- a/client/src/components/util/truncate.tsx
+++ b/client/src/components/util/truncate.tsx
@@ -99,13 +99,17 @@ export default (props: any) => {
       {tooltipAddendum}
     </span>
   );
+
+  const originalContent = (
+    <span data-chromatic="ignore">
+      {originalString}
+      {tooltipAddendum}
+    </span>
+  );
+
   return (
     <Tooltip2
-      content={
-        isGenesetDescription
-          ? descriptionContent
-          : `${originalString}${tooltipAddendum}`
-      }
+      content={isGenesetDescription ? descriptionContent : originalContent}
       hoverOpenDelay={tooltipHoverOpenDelayQuick}
       // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
       targetProps={{ style: children.props.style }}


### PR DESCRIPTION
1. Add Chromatic screenshots where the graph matters
2. Stabilize test steps by using `tryUntil()` and short assertion timeout to fail fast and retry
3. Add `data-chromatic="ignore"` to more elements