### PR TITLE
fix: remove implicit state toggling for spatial underlay in favor of explicit state setting

### DIFF
--- a/client/src/components/embedding/index.tsx
+++ b/client/src/components/embedding/index.tsx
@@ -46,9 +46,13 @@ class Embedding extends React.PureComponent<{}, EmbeddingState> {
     track(EVENTS.EXPLORER_LAYOUT_CHOICE_CHANGE_ITEM_CLICKED);
 
     dispatch(actions.layoutChoiceAction(e.currentTarget.value));
-    if (imageUnderlay && e.target.value !== globals.spatialEmbeddingKeyword) {
+    if (
+      imageUnderlay &&
+      !e.target.value.includes(globals.spatialEmbeddingKeyword)
+    ) {
       dispatch({
         type: "toggle image underlay",
+        toggle: false,
       });
     }
   };

--- a/client/src/components/menubar/index.tsx
+++ b/client/src/components/menubar/index.tsx
@@ -106,6 +106,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     if (currentConditionMet) {
       dispatch({
         type: "toggle image underlay",
+        toggle: true,
       });
     }
   }
@@ -123,6 +124,7 @@ class MenuBar extends React.PureComponent<{}, State> {
     if (!prevConditionMet && currentConditionMet) {
       dispatch({
         type: "toggle image underlay",
+        toggle: true,
       });
     }
   }
@@ -438,6 +440,7 @@ class MenuBar extends React.PureComponent<{}, State> {
                     onClick={() => {
                       dispatch({
                         type: "toggle image underlay",
+                        toggle: !imageUnderlay,
                       });
                     }}
                   />

--- a/client/src/reducers/controls.ts
+++ b/client/src/reducers/controls.ts
@@ -455,6 +455,7 @@ const Controls = (
          Uns/Spatial
     **************************/
     case "toggle image underlay": {
+      if (state.imageUnderlay === action.toggle) return state;
       return {
         ...state,
         imageUnderlay: action.toggle,

--- a/client/src/reducers/controls.ts
+++ b/client/src/reducers/controls.ts
@@ -457,7 +457,7 @@ const Controls = (
     case "toggle image underlay": {
       return {
         ...state,
-        imageUnderlay: !state.imageUnderlay,
+        imageUnderlay: action.toggle,
       };
     }
     case "request uns metadata started":


### PR DESCRIPTION
Old redux action handling image underlay display state was error-prone. This PR removes the reducer's implicit state toggling with explicit state sent via the action payload