### PR TITLE
fix: unit tests and slight refactor

### DIFF
--- a/server/common/constants.py
+++ b/server/common/constants.py
@@ -2,16 +2,16 @@ from enum import Enum
 
 
 class AugmentedEnum(Enum):
-    def __hash__(self):
+    def __hash__(self):  # type: ignore
         return self.value.__hash__()
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # type: ignore
         if isinstance(other, (type(self), str)):
             return self.value == other
         return False
 
-    def __str__(self) -> str:
-        return self.value
+    def __str__(self) -> str:  # type: ignore
+        return self.value  # type: ignore
 
 
 class Axis(AugmentedEnum):

--- a/server/common/utils/uns.py
+++ b/server/common/utils/uns.py
@@ -1,0 +1,60 @@
+import base64
+import io
+
+import numpy as np
+from PIL import Image
+
+from server.common.constants import SPATIAL_IMAGE_DEFAULT_RES
+
+
+def crop_box(image_size):  # type: ignore
+    """
+    Calculate the cropping box for a 1:1 aspect ratio for spatial images
+    """
+    width, height = image_size
+
+    # The new dimensions will be the smaller of the width or height
+    new_dimension = min(width, height)
+
+    # Calculate the cropping box
+    left = (width - new_dimension) / 2
+    upper = (height - new_dimension) / 2
+    right = (width + new_dimension) / 2
+    lower = (height + new_dimension) / 2
+
+    return (left, upper, right, lower)
+
+
+def spatial_metadata_get(spatial):  # type: ignore
+    """
+    Returns an object containing spatial metadata, including image width and image height
+    """
+    resolution = SPATIAL_IMAGE_DEFAULT_RES
+
+    try:
+        library_id = list(spatial.keys())[0]
+        image_array = spatial[library_id]["images"][resolution]
+    except KeyError as e:
+        raise Exception(f"spatial information does not contain requested resolution '{resolution}'") from e
+
+    response_image = io.BytesIO()
+
+    image = Image.fromarray(np.uint8(image_array * 255))
+    image = image.crop(crop_box(image.size))  # type: ignore
+    image.save(response_image, format="WEBP", quality=90)
+
+    image_str = base64.b64encode(response_image.getvalue()).decode()
+
+    (h, w, _) = image_array.shape
+    h = w = min(h, w)  # adjust for 1:1 aspect ratio
+
+    spatial_metadata = {
+        "spatial": {
+            "imageWidth": h,
+            "imageHeight": w,
+            "libraryId": library_id,
+            "image": image_str,
+        }
+    }
+
+    return spatial_metadata

--- a/server/common/utils/utils.py
+++ b/server/common/utils/utils.py
@@ -87,21 +87,3 @@ def custom_format_warning(msg, *args, **kwargs):  # type: ignore
 
 def jsonify_numpy(data):  # type: ignore
     return json.dumps(data, cls=Float32JSONEncoder, allow_nan=False)
-
-
-def crop_box(image_size):  # type: ignore
-    """
-    Calculate the cropping box for a 1:1 aspect ratio for spatial images
-    """
-    width, height = image_size
-
-    # The new dimensions will be the smaller of the width or height
-    new_dimension = min(width, height)
-
-    # Calculate the cropping box (left, upper, right, lower)
-    left = (width - new_dimension) / 2
-    upper = (height - new_dimension) / 2
-    right = (width + new_dimension) / 2
-    lower = (height + new_dimension) / 2
-
-    return (left, upper, right, lower)

--- a/server/dataset/dataset.py
+++ b/server/dataset/dataset.py
@@ -15,7 +15,8 @@ from server.common.errors import (
     UnsupportedSummaryMethod,
 )
 from server.common.fbs.matrix import encode_matrix_fbs
-from server.common.utils.utils import crop_box, jsonify_numpy
+from server.common.utils.utils import jsonify_numpy
+from server.common.utils.uns import crop_box
 
 
 class Dataset(metaclass=ABCMeta):

--- a/server/dataset/dataset.py
+++ b/server/dataset/dataset.py
@@ -15,8 +15,8 @@ from server.common.errors import (
     UnsupportedSummaryMethod,
 )
 from server.common.fbs.matrix import encode_matrix_fbs
-from server.common.utils.utils import jsonify_numpy
 from server.common.utils.uns import crop_box
+from server.common.utils.utils import jsonify_numpy
 
 
 class Dataset(metaclass=ABCMeta):

--- a/server/tests/__init__.py
+++ b/server/tests/__init__.py
@@ -4,6 +4,7 @@ from os import popen
 
 PROJECT_ROOT = popen("git rev-parse --show-toplevel").read().strip()
 FIXTURES_ROOT = PROJECT_ROOT + "/server/tests/fixtures"
+FIXTURES_ROOT_UNS = PROJECT_ROOT + "/example-dataset/"
 
 
 def random_string(n):

--- a/server/tests/unit/common/apis/test_api_v3.py
+++ b/server/tests/unit/common/apis/test_api_v3.py
@@ -754,6 +754,7 @@ class EndPoints(BaseTest):
                 "imageWidth": 1955,
                 "imageHeight": 1955,
                 "libraryId": "HCAHeartST13233999",
+                "image": "484f7e831642a66fadebc8231ad4eeaf1dff1b39",
             }
         }
         for url_base in [self.TEST_UNS_URL_BASE]:
@@ -761,14 +762,13 @@ class EndPoints(BaseTest):
                 url = f"{url_base}{endpoint}?{query}"
                 header = {"Accept": "application/ojson"}
                 result = self.client.get(url, headers=header)
+
                 self.assertEqual(result.status_code, HTTPStatus.OK)
                 self.assertEqual(result.headers["Content-Type"], "application/json")
-                result_data = json.loads(result.data)
 
-                # To avoid clutter of a large endcoded image string as part of the expected response,
-                # we verify that the image field is present in the response then remove it for assertion
-                assert "image" in result_data["spatial"]
-                del result_data["spatial"]["image"]
+                result_data = json.loads(result.data)
+                # hash the image string and compare with expected response hash
+                result_data["spatial"]["image"] = hashlib.sha1(result_data["spatial"]["image"].encode()).hexdigest()
                 self.assertEqual(result_data, uns_meta_expected_response)
 
 

--- a/server/tests/unit/common/apis/test_api_v3.py
+++ b/server/tests/unit/common/apis/test_api_v3.py
@@ -739,7 +739,7 @@ class EndPoints(BaseTest):
         for url_base in [self.TEST_URL_BASE]:
             with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?{query}"
-                header = {"Content-Type": "application/json"}
+                header = {"Accept": "application/json"}
                 result = self.client.get(url, headers=header)
                 self.assertEqual(result.status_code, HTTPStatus.OK)
                 self.assertEqual(result.headers["Content-Type"], "application/json")

--- a/server/tests/unit/common/apis/test_api_v3.py
+++ b/server/tests/unit/common/apis/test_api_v3.py
@@ -54,7 +54,6 @@ class EndPoints(BaseTest):
         cls.TEST_UNS_S3_URI = f"{FIXTURES_ROOT_UNS}/super-cool-spatial.cxg"
         cls.TEST_UNS_S3_URI_ENCODED = cls.encode_s3_uri(cls.TEST_UNS_S3_URI)
         cls.TEST_UNS_DATASET_URL_BASE = f"/s3_uri/{cls.TEST_UNS_S3_URI_ENCODED}"
-        
         cls.TEST_UNS_URL_BASE = f"{cls.TEST_UNS_DATASET_URL_BASE}/api/v0.3/"
 
         cls.app.testing = True

--- a/server/tests/unit/common/apis/test_api_v3.py
+++ b/server/tests/unit/common/apis/test_api_v3.py
@@ -739,7 +739,7 @@ class EndPoints(BaseTest):
         for url_base in [self.TEST_URL_BASE]:
             with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?{query}"
-                header = {"Accept": "application/ojson"}
+                header = {"Content-Type": "application/json"}
                 result = self.client.get(url, headers=header)
                 self.assertEqual(result.status_code, HTTPStatus.OK)
                 self.assertEqual(result.headers["Content-Type"], "application/json")
@@ -760,7 +760,7 @@ class EndPoints(BaseTest):
         for url_base in [self.TEST_UNS_URL_BASE]:
             with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?{query}"
-                header = {"Accept": "application/ojson"}
+                header = {"Content-Type": "application/json"}
                 result = self.client.get(url, headers=header)
 
                 self.assertEqual(result.status_code, HTTPStatus.OK)

--- a/server/tests/unit/common/apis/test_api_v3.py
+++ b/server/tests/unit/common/apis/test_api_v3.py
@@ -751,12 +751,12 @@ class EndPoints(BaseTest):
         endpoint = "uns/meta"
         query = "key=spatial"
         uns_meta_expected_response = {
-                            "spatial": {
-                                "imageWidth": 1955,
-                                "imageHeight": 1955,
-                                "libraryId": "HCAHeartST13233999",
-                            }
-                        }
+            "spatial": {
+                "imageWidth": 1955,
+                "imageHeight": 1955,
+                "libraryId": "HCAHeartST13233999",
+            }
+        }
         for url_base in [self.TEST_UNS_URL_BASE]:
             with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?{query}"

--- a/server/tests/unit/common/apis/test_api_v3.py
+++ b/server/tests/unit/common/apis/test_api_v3.py
@@ -760,7 +760,7 @@ class EndPoints(BaseTest):
         for url_base in [self.TEST_UNS_URL_BASE]:
             with self.subTest(url_base=url_base):
                 url = f"{url_base}{endpoint}?{query}"
-                header = {"Content-Type": "application/json"}
+                header = {"Accept": "application/json"}
                 result = self.client.get(url, headers=header)
 
                 self.assertEqual(result.status_code, HTTPStatus.OK)


### PR DESCRIPTION
Added 2 unit tests:

`test_uns_no_metadata_get` - for dataset without `uns` array or spatial
`test_uns_metadata_get` - for dataset with `uns` array and spatial

Slight refactor to extract metadata helper functions to a dedicated utils file