### PR TITLE
feat: allow argus throught he CORS policy

### DIFF
--- a/server/ecs/app.py
+++ b/server/ecs/app.py
@@ -76,6 +76,12 @@ class WSGIServer(Server):
                         r"^http://localhost:\d+",
                     ]
                 )
+            if os.getenv("DEPLOYMENT_STAGE") in ["Dev", "dev"]:
+                allowed_origins.extend(
+                    [
+                        r"^https://(.*).sc.dev.czi.team/",
+                    ]
+                )
             CORS(app, supports_credentials=True, origins=allowed_origins)
 
         Talisman(

--- a/server/ecs/app.py
+++ b/server/ecs/app.py
@@ -74,6 +74,7 @@ class WSGIServer(Server):
                     [
                         "https://canary-cellxgene.dev.single-cell.czi.technology/",
                         r"^http://localhost:\d+",
+                        r"^https://(.*).sc.dev.czi.team/",
                     ]
                 )
             if os.getenv("DEPLOYMENT_STAGE") in ["Dev", "dev"]:


### PR DESCRIPTION
## Summary

In the dev environments, all argus stack URL to be allowed through the CORS policy. All these URLS are generated with random subdomains, but all end with ".sc.dev.czi.team", for example https://special-worm.sc.dev.czi.team.

## References

* https://github.com/chanzuckerberg/single-cell-explorer/pull/886