### PR TITLE
feat: Home button

### DIFF
--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -7,11 +7,12 @@ import { mat3, vec2 } from "gl-matrix";
 import _regl, { DrawCommand, Regl } from "regl";
 import memoize from "memoize-one";
 import Async from "react-async";
-import { Button } from "@blueprintjs/core";
+import { Button, Icon } from "@blueprintjs/core";
 
 import Openseadragon, { Viewer } from "openseadragon";
 
 import { throttle } from "lodash";
+import { IconNames } from "@blueprintjs/icons";
 import { setupBrush, setupLasso } from "./setupSVGandBrush";
 import _camera, { Camera } from "../../util/camera";
 import _drawPoints from "./drawPointsRegl";
@@ -288,6 +289,7 @@ class Graph extends React.Component<GraphProps, GraphState> {
       updateOverlay: false,
       testImageSrc: null,
       isDeepZoomSourceValid: true,
+      isImageLayerInViewport: true,
     };
 
     this.throttledHandleResize = throttle(
@@ -1006,6 +1008,14 @@ class Graph extends React.Component<GraphProps, GraphState> {
 
       postUserErrorToast("The image is not available");
     });
+
+    this.openseadragon.addHandler(
+      "viewport-change",
+      /**
+       * (thuang): Binding `this` to the function to access the openseadragon instance
+       */
+      this.checkIsImageLayerInViewport.bind(this)
+    );
   }
 
   destroyOpenseadragon() {
@@ -1027,6 +1037,37 @@ class Graph extends React.Component<GraphProps, GraphState> {
     const tiledImage = this.openseadragon.world.getItemAt(0); // Get the first image
 
     tiledImage?.setOpacity(1);
+  }
+
+  checkIsImageLayerInViewport() {
+    if (!this.openseadragon) return;
+
+    const bounds = this.openseadragon.world.getItemAt(0)?.getBounds();
+    const viewportBounds = this.openseadragon.viewport?.getBounds();
+
+    if (!bounds || !viewportBounds) return;
+
+    const imageOutsideViewport =
+      bounds.x > viewportBounds.x + viewportBounds.width ||
+      bounds.x + bounds.width < viewportBounds.x ||
+      bounds.y > viewportBounds.y + viewportBounds.height ||
+      bounds.y + bounds.height < viewportBounds.y;
+
+    if (imageOutsideViewport) {
+      this.setState((state) => {
+        if (state.isImageLayerInViewport === false) return state;
+
+        return { ...state, isImageLayerInViewport: false };
+      });
+
+      return;
+    }
+
+    this.setState((state) => {
+      if (state.isImageLayerInViewport === true) return state;
+
+      return { ...state, isImageLayerInViewport: true };
+    });
   }
 
   async renderPoints(
@@ -1133,8 +1174,15 @@ class Graph extends React.Component<GraphProps, GraphState> {
       spatial,
     } = this.props;
 
-    const { modelTF, projectionTF, camera, viewport, regl, testImageSrc } =
-      this.state;
+    const {
+      modelTF,
+      projectionTF,
+      camera,
+      viewport,
+      regl,
+      testImageSrc,
+      isImageLayerInViewport,
+    } = this.state;
 
     const cameraTF = camera?.view()?.slice();
 
@@ -1142,25 +1190,35 @@ class Graph extends React.Component<GraphProps, GraphState> {
       <div
         id="graph-wrapper"
         style={{
-          position: "relative",
           top: 0,
+          position: "relative",
           left: 0,
+          flexDirection: "column",
+          display: "flex",
+          alignItems: "center",
         }}
         data-testid="graph-wrapper"
         data-camera-distance={camera?.distance()}
         ref={this.graphRef}
       >
-        <button
-          onClick={this.handleGoHome}
-          type="button"
-          style={{
-            position: "absolute",
-            top: "55px",
-            zIndex: 20,
-          }}
-        >
-          Go Home
-        </button>
+        {isSpatialMode(this.props) && isImageLayerInViewport === false && (
+          <Button
+            onClick={this.handleGoHome}
+            type="button"
+            style={{
+              justifyContent: "center",
+              width: "fit-content",
+              zIndex: 3,
+              marginTop: "60px",
+            }}
+          >
+            <Icon
+              icon={IconNames.LOCATE}
+              style={{ marginLeft: "0", marginRight: "4px" }}
+            />
+            Re-center Embedding
+          </Button>
+        )}
 
         <GraphOverlayLayer
           /**  @ts-expect-error TODO: type GraphOverlayLayer**/

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -1054,20 +1054,20 @@ class Graph extends React.Component<GraphProps, GraphState> {
       bounds.y + bounds.height < viewportBounds.y;
 
     if (imageOutsideViewport) {
-      this.setState((state) => {
-        if (state.isImageLayerInViewport === false) return state;
-
-        return { ...state, isImageLayerInViewport: false };
-      });
+      this.setState((state) =>
+        state.isImageLayerInViewport
+          ? { ...state, isImageLayerInViewport: false }
+          : state
+      );
 
       return;
     }
 
-    this.setState((state) => {
-      if (state.isImageLayerInViewport === true) return state;
-
-      return { ...state, isImageLayerInViewport: true };
-    });
+    this.setState((state) =>
+      state.isImageLayerInViewport
+        ? state
+        : { ...state, isImageLayerInViewport: true }
+    );
   }
 
   async renderPoints(

--- a/client/src/components/graph/types.ts
+++ b/client/src/components/graph/types.ts
@@ -45,4 +45,5 @@ export type GraphState = {
   modelInvTF: ReadonlyMat3;
   testImageSrc: string | null;
   isDeepZoomSourceValid: boolean;
+  isImageLayerInViewport: boolean;
 };

--- a/client/src/components/menubar/diffexpButtons.tsx
+++ b/client/src/components/menubar/diffexpButtons.tsx
@@ -70,7 +70,7 @@ class DiffexpButtons extends React.PureComponent {
             intent={warnMaxSizeExceeded ? "danger" : "primary"}
             data-testid="diffexp-button"
             loading={differential.loading}
-            icon="left-join"
+            icon="target"
             fill
             onClick={this.computeDiffExp}
           />

--- a/client/src/components/menubar/index.tsx
+++ b/client/src/components/menubar/index.tsx
@@ -300,8 +300,6 @@ class MenuBar extends React.PureComponent<{}, State> {
       screenCap,
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'subsetResetPossible' does not exist on t... Remove this comment to see the full error message
       imageUnderlay,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'subsetResetPossible' does not exist on t... Remove this comment to see the full error message
-      layoutChoice,
     } = this.props;
     const { pendingClipPercentiles } = this.state;
 
@@ -325,6 +323,7 @@ class MenuBar extends React.PureComponent<{}, State> {
           justifyContent: "space-between",
           width: "100%",
         }}
+        data-test-id="menubar"
       >
         <div
           style={{


### PR DESCRIPTION
close #910

1. Add Home Button ONLY to spatial mode, because it turned out to be pretty difficult to detect when the embedding layer is out of the viewport or not, whereas Openseadragon has built in feature we can leverage to check it
2. Only show the Home Button when the image is fully out of the viewport
3. Add back pan and zoom bound to NON-SPATIAL modes, so they don't need the home button

Implementation:
1. On Openseadragon `viewport-change` event, we run a function to check if the image layer is in viewport or not and set new state `isImageLayerInViewport` if it's different from the current state
2. `render` function will just check `isImageLayerInViewport` to see if it should render the home button
3. Home button on click will call `goHome()` function, which triggers Openseadragon to re-center and emits `viewport-change` event to update state `isImageLayerInViewport`

<img width="1014" alt="Screenshot 2024-05-15 at 8 54 10 AM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/4586308a-2aec-4bb6-859d-f80a5077cdaa">

https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/bc1a12ea-1aa2-4965-a91a-2b10722b1eaa

