### PR TITLE
fix: 936 embedding cell count

### DIFF
--- a/client/src/components/embedding/index.tsx
+++ b/client/src/components/embedding/index.tsx
@@ -16,9 +16,9 @@ import actions from "../../actions";
 import { getDiscreteCellEmbeddingRowIndex } from "../../util/stateManager/viewStackHelpers";
 import { track } from "../../analytics";
 import { EVENTS } from "../../analytics/events";
+import { RootState } from "../../reducers";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-type EmbeddingState = any;
+type Props = RootState;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state: RootState) => ({
@@ -27,12 +27,11 @@ type EmbeddingState = any;
   crossfilter: state.obsCrossfilter,
   imageUnderlay: state.imageUnderlay,
 }))
-// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
-class Embedding extends React.PureComponent<{}, EmbeddingState> {
-  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
-  constructor(props: {}) {
-    super(props);
-    this.state = {};
+class Embedding extends React.PureComponent<Props> {
+  componentDidMount(): void {
+    const { dispatch, layoutChoice } = this.props;
+
+    dispatch(actions.layoutChoiceAction(layoutChoice.current));
   }
 
   handleLayoutChoiceClick = (): void => {
@@ -40,7 +39,6 @@ class Embedding extends React.PureComponent<{}, EmbeddingState> {
   };
 
   handleLayoutChoiceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, imageUnderlay } = this.props;
 
     track(EVENTS.EXPLORER_LAYOUT_CHOICE_CHANGE_ITEM_CLICKED);
@@ -59,7 +57,6 @@ class Embedding extends React.PureComponent<{}, EmbeddingState> {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'layoutChoice' does not exist on type 'Re... Remove this comment to see the full error message
     const { layoutChoice, schema, crossfilter } = this.props;
     const { annoMatrix } = crossfilter;
 


### PR DESCRIPTION
fix #936 

1. In `componentDidMount()` we now dispatch `dispatch(actions.layoutChoiceAction(layoutChoice.current));` to ensure that we apply the correct cross filter as expected in order to get the correct cell count

NOTES:
1. I don't have a dataset to test this locally, but at least I'm getting the same error message on mount as when I was manually switching from `umap` to `pca`. So I think it's working lol?

<img width="994" alt="Screenshot 2024-05-21 at 1 46 22 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/d1bc5212-4b8d-4af3-9337-4323f57529e9">
