### PR TITLE
fix: 940 hide image toggle

### DIFF
--- a/client/src/actions/config.ts
+++ b/client/src/actions/config.ts
@@ -1,0 +1,5 @@
+export function fetchDeepZoomImageFailed() {
+  return {
+    type: "fetchDeepZoomImageFailed",
+  };
+}

--- a/client/src/common/selectors.ts
+++ b/client/src/common/selectors.ts
@@ -1,8 +1,25 @@
 import { spatialEmbeddingKeyword } from "../globals";
 import { RootState } from "../reducers";
+import { selectIsDeepZoomSourceValid, selectS3URI } from "../selectors/config";
+import { getFeatureFlag } from "../util/featureFlags/featureFlags";
+import { FEATURES } from "../util/featureFlags/features";
 
 export function isSpatialMode(props: Partial<RootState>) {
   const { layoutChoice } = props;
 
   return layoutChoice?.current?.includes(spatialEmbeddingKeyword);
+}
+
+const isSpatial = getFeatureFlag(FEATURES.SPATIAL);
+
+/**
+ * (thuang): Selector to determine if the OpenSeadragon viewer should be shown
+ */
+export function shouldShowOpenseadragon(props: Partial<RootState>) {
+  return (
+    isSpatial &&
+    selectIsDeepZoomSourceValid(props) &&
+    selectS3URI(props) &&
+    isSpatialMode(props)
+  );
 }

--- a/client/src/components/graph/types.ts
+++ b/client/src/components/graph/types.ts
@@ -44,6 +44,5 @@ export type GraphState = {
   modelTF: ReadonlyMat3;
   modelInvTF: ReadonlyMat3;
   testImageSrc: string | null;
-  isDeepZoomSourceValid: boolean;
   isImageLayerInViewport: boolean;
 };

--- a/client/src/components/graph/util.ts
+++ b/client/src/components/graph/util.ts
@@ -1,9 +1,5 @@
 import { mat3 } from "gl-matrix";
 import { toPng } from "html-to-image";
-import { GraphProps, GraphState } from "./types";
-import { getFeatureFlag } from "../../util/featureFlags/featureFlags";
-import { FEATURES } from "../../util/featureFlags/features";
-import { isSpatialMode as isSpatialModeSelector } from "../../common/selectors";
 import { LayoutChoiceState } from "../../reducers/layoutChoice";
 
 export async function captureLegend(
@@ -182,23 +178,6 @@ function getSpatialUrl(s3URI: string) {
 
 function getDatasetVersionId(s3URI: string) {
   return s3URI.split("/").at(-1)?.split(".cxg")[0];
-}
-
-const isSpatial = getFeatureFlag(FEATURES.SPATIAL);
-
-/**
- * (thuang): Selector to determine if the OpenSeadragon viewer should be shown
- */
-export function shouldShowOpenseadragon(props: GraphProps, state: GraphState) {
-  const { isDeepZoomSourceValid } = state;
-
-  const {
-    config: { s3URI },
-  } = props;
-
-  return (
-    isSpatial && isDeepZoomSourceValid && s3URI && isSpatialModeSelector(props)
-  );
 }
 
 export function loadImage(src: string): Promise<HTMLImageElement> {

--- a/client/src/components/menubar/index.tsx
+++ b/client/src/components/menubar/index.tsx
@@ -19,7 +19,7 @@ import { EVENTS } from "../../analytics/events";
 import Embedding from "../embedding";
 import { getFeatureFlag } from "../../util/featureFlags/featureFlags";
 import { FEATURES } from "../../util/featureFlags/features";
-import { isSpatialMode } from "../../common/selectors";
+import { shouldShowOpenseadragon } from "../../common/selectors";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 type State = any;
@@ -61,6 +61,7 @@ type State = any;
     screenCap: state.controls.screenCap,
     imageUnderlay: state.controls.imageUnderlay,
     layoutChoice: state.layoutChoice,
+    config: state.config,
   };
 })
 // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
@@ -274,10 +275,6 @@ class MenuBar extends React.PureComponent<{}, State> {
       dispatch,
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'disableDiffexp' does not exist on type '... Remove this comment to see the full error message
       disableDiffexp,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'undoDisabled' does not exist on type 'Re... Remove this comment to see the full error message
-      undoDisabled,
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'redoDisabled' does not exist on type 'Re... Remove this comment to see the full error message
-      redoDisabled,
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'selectionTool' does not exist on type 'R... Remove this comment to see the full error message
       selectionTool,
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'clipPercentileMin' does not exist on typ... Remove this comment to see the full error message
@@ -307,7 +304,7 @@ class MenuBar extends React.PureComponent<{}, State> {
 
     const isTest = getFeatureFlag(FEATURES.TEST);
     const isDownload = getFeatureFlag(FEATURES.DOWNLOAD);
-    const isSpatial = getFeatureFlag(FEATURES.SPATIAL);
+
     // constants used to create selection tool button
     const [selectionTooltip, selectionButtonIcon] =
       selectionTool === "brush"
@@ -423,7 +420,7 @@ class MenuBar extends React.PureComponent<{}, State> {
               disabled={!isColoredByCategorical}
             />
           </Tooltip>
-          {isSpatialMode(this.props) && isSpatial && (
+          {shouldShowOpenseadragon(this.props) && (
             <ButtonGroup className={styles.menubarButton}>
               <Tooltip
                 content="Toggle image"

--- a/client/src/reducers/config.ts
+++ b/client/src/reducers/config.ts
@@ -1,7 +1,7 @@
 import { AnyAction } from "redux";
 import type { Config } from "../globals";
 
-interface ConfigState {
+export interface ConfigState {
   features: Config["features"] | null;
   parameters: Config["parameters"] | null;
   displayNames: Config["displayNames"] | null;
@@ -11,12 +11,15 @@ interface ConfigState {
   library_versions?: Config["library_versions"];
   portalUrl?: Config["portalUrl"];
   links?: Config["links"];
+  s3URI?: string;
+  isDeepZoomSourceValid: boolean;
 }
 const ConfigReducer = (
   state: ConfigState = {
     displayNames: null,
     features: null,
     parameters: null,
+    isDeepZoomSourceValid: true,
   },
   action: AnyAction
 ) => {
@@ -46,6 +49,11 @@ const ConfigReducer = (
       return {
         ...state,
         error: action.error,
+      };
+    case "fetchDeepZoomImageFailed":
+      return {
+        ...state,
+        isDeepZoomSourceValid: false,
       };
     default:
       return state;

--- a/client/src/selectors/config.ts
+++ b/client/src/selectors/config.ts
@@ -1,0 +1,20 @@
+import { RootState } from "../reducers";
+import { ConfigState } from "../reducers/config";
+
+export function selectConfig(state: RootState): ConfigState {
+  return state.config;
+}
+
+export function selectS3URI(state: RootState): ConfigState["s3URI"] {
+  const config = selectConfig(state);
+
+  return config.s3URI;
+}
+
+export function selectIsDeepZoomSourceValid(
+  state: RootState
+): ConfigState["isDeepZoomSourceValid"] {
+  const config = selectConfig(state);
+
+  return config.isDeepZoomSourceValid;
+}


### PR DESCRIPTION
fix: #940

1. Move state `isDeepZoomSourceValid` into `config` reducer, so both Graph and Menubar components can use that state
2. Extract selector `shouldShowOpenseadragon` to `client/src/common/selectors.ts` to be used by the components above
3. Create `config` selector file


https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/7d12238b-e172-46f4-9d94-4decc71f3490

