### PR TITLE
fix: 936 embedding cell count

### DIFF
--- a/client/src/components/embedding/index.tsx
+++ b/client/src/components/embedding/index.tsx
@@ -16,9 +16,9 @@ import actions from "../../actions";
 import { getDiscreteCellEmbeddingRowIndex } from "../../util/stateManager/viewStackHelpers";
 import { track } from "../../analytics";
 import { EVENTS } from "../../analytics/events";
+import { RootState } from "../../reducers";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
-type EmbeddingState = any;
+type Props = RootState;
 
 // @ts-expect-error ts-migrate(1238) FIXME: Unable to resolve signature of class decorator whe... Remove this comment to see the full error message
 @connect((state: RootState) => ({
@@ -27,20 +27,12 @@ type EmbeddingState = any;
   crossfilter: state.obsCrossfilter,
   imageUnderlay: state.imageUnderlay,
 }))
-// eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
-class Embedding extends React.PureComponent<{}, EmbeddingState> {
-  // eslint-disable-next-line @typescript-eslint/ban-types --- FIXME: disabled temporarily on migrate to TS.
-  constructor(props: {}) {
-    super(props);
-    this.state = {};
-  }
-
+class Embedding extends React.PureComponent<Props> {
   handleLayoutChoiceClick = (): void => {
     track(EVENTS.EXPLORER_LAYOUT_CHOICE_BUTTON_CLICKED);
   };
 
   handleLayoutChoiceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'dispatch' does not exist on type 'Readon... Remove this comment to see the full error message
     const { dispatch, imageUnderlay } = this.props;
 
     track(EVENTS.EXPLORER_LAYOUT_CHOICE_CHANGE_ITEM_CLICKED);
@@ -59,7 +51,6 @@ class Embedding extends React.PureComponent<{}, EmbeddingState> {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
   render() {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'layoutChoice' does not exist on type 'Re... Remove this comment to see the full error message
     const { layoutChoice, schema, crossfilter } = this.props;
     const { annoMatrix } = crossfilter || {};
 

--- a/client/src/selectors/annoMatrix.ts
+++ b/client/src/selectors/annoMatrix.ts
@@ -1,17 +1,17 @@
 /* App dependencies */
+import AnnoMatrix from "../annoMatrix/annoMatrix";
 import { AnnotationColumnSchema } from "../common/types/schema";
-import { RootState } from "../reducers";
+import { type RootState } from "../reducers";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any --- update typings once annoMatrix reducer state is typed.
-export const selectAnnoMatrix = (state: RootState): any => state.annoMatrix;
+export const selectAnnoMatrix = (state: RootState): AnnoMatrix =>
+  state.annoMatrix;
 
 /*
  Returns true if user defined category has been created indicating work is in progress.
  @param annoMatrix from state
  @returns boolean
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any --- update typings once annoMatrix reducer state is typed.
-export const selectIsUserStateDirty = (state: any): boolean => {
+export const selectIsUserStateDirty = (state: RootState): boolean => {
   const annoMatrix = selectAnnoMatrix(state);
 
   return Boolean(
@@ -20,3 +20,8 @@ export const selectIsUserStateDirty = (state: any): boolean => {
     )
   );
 };
+
+export function selectSchema(state: RootState) {
+  const annoMatrix = selectAnnoMatrix(state);
+  return annoMatrix?.schema;
+}

--- a/client/src/selectors/layoutChoice.ts
+++ b/client/src/selectors/layoutChoice.ts
@@ -1,0 +1,11 @@
+import { EmbeddingSchema } from "../common/types/schema";
+import { type RootState } from "../reducers";
+import { selectAnnoMatrix } from "./annoMatrix";
+
+export function selectAvailableLayouts(state: RootState): string[] {
+  const annoMatrix = selectAnnoMatrix(state);
+
+  return (annoMatrix.schema?.layout?.obs || [])
+    .map((v: EmbeddingSchema) => v.name)
+    .sort();
+}


### PR DESCRIPTION
Fix #936 

1. `doInitialDataLoad` action now choose the initial layout by checking if the dataset's preferred `default_embedding` is available or not and fall back to picking the best layout given the available layouts
2. This resolves two bugs:
    1. On page load, we no longer get the layout flickering caused by the layoutChoice first setting a fallback layout, and then switching to the dataset preferred layout
    2. Fixes #936
3. Extract a new selector `selectAvailableLayouts ` to reuse

https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/ac978673-82d4-4b72-be01-a41593d2b2da

