### PR TITLE
fix: 858 jason bug 2

### DIFF
--- a/client/src/actions/embedding.ts
+++ b/client/src/actions/embedding.ts
@@ -17,24 +17,38 @@ async function _switchEmbedding(
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   prevCrossfilter: any,
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  newEmbeddingName: any
+  newEmbeddingName: any,
+  prevEmbeddingName = ""
 ) {
-  /*
-  DRY helper used by embedding action creators
-  */
+  /**
+   * DRY helper used by embedding action creators
+   */
   const base = prevAnnoMatrix.base();
+
   const embeddingDf = await base.fetch(
     "emb",
     newEmbeddingName,
     globals.numBinsEmb
   );
+
   const annoMatrix = _setEmbeddingSubset(prevAnnoMatrix, embeddingDf);
+
   const obsCrossfilter = await new AnnoMatrixObsCrossfilter(
     annoMatrix,
     prevCrossfilter.obsCrossfilter
-  ).select(Field.emb, newEmbeddingName, {
-    mode: "all",
-  });
+  )
+    /**
+     * (thuang + seve): When switching embeddings, if the previous selection mode is "all",
+     * we should remove the embedding dimension from the crossfilter. Otherwise, the crossfilter
+     * will select the intersection of the total cell counts between the previous embedding and
+     * the new embedding. If the two embeddings have different cell counts, this will result in a bug.
+     * See the issue for more details: https://github.com/chanzuckerberg/single-cell-explorer/issues/858
+     */
+    .dropDimension(Field.emb, prevEmbeddingName)
+    .select(Field.emb, newEmbeddingName, {
+      mode: "all",
+    });
+
   return [annoMatrix, obsCrossfilter];
 }
 
@@ -43,17 +57,31 @@ export const layoutChoiceAction: ActionCreator<
 > =
   (newLayoutChoice: string) =>
   async (dispatch: AppDispatch, getState: GetState): Promise<void> => {
-    /*
-  On layout choice, make sure we have selected all on the previous layout, AND the new
-  layout.
-  */
-    const { annoMatrix: prevAnnoMatrix, obsCrossfilter: prevCrossfilter } =
-      getState();
+    /**
+     * Bruce: On layout choice, make sure we have selected all on the previous layout, AND the new
+     * layout.
+     */
+    const {
+      annoMatrix: prevAnnoMatrix,
+      obsCrossfilter: prevCrossfilter,
+      layoutChoice: prevLayoutChoice,
+      graphSelection: { selection },
+    } = getState();
+
+    /**
+     * (thuang + seve): When switching embeddings, if the previous selection mode is "all",
+     * we should remove the embedding dimension from the crossfilter. Otherwise, the crossfilter
+     * will select the intersection of the total cell counts between the previous embedding and
+     * the new embedding. If the two embeddings have different cell counts, this will result in a bug.
+     * See the issue for more details: https://github.com/chanzuckerberg/single-cell-explorer/issues/858
+     */
+    const shouldRemoveEmbeddingDimension = selection?.mode === "all";
 
     const [annoMatrix, obsCrossfilter] = await _switchEmbedding(
       prevAnnoMatrix,
       prevCrossfilter,
-      newLayoutChoice
+      newLayoutChoice,
+      shouldRemoveEmbeddingDimension ? prevLayoutChoice.current : ""
     );
 
     dispatch({


### PR DESCRIPTION
fix #858

Context:
1. Jason discovered a bug where when switching from an embedding with less cells to an embedding with more cells (e.g., `umap` -> `spatial`), some cells in `spatial` embedding will remain unselected
2. The reason is because the cross filter unnecessarily keeps previous embedding dimension in its `dimensions` property when the selection mode is `all`, which causes `BitArray.countAllOnes` to return the selection intersection of both `umap` and `spatial` dimensions, which is the lesser amount

Solution:
1. The fix proposed by @seve and @atarashansky (thanks so much for both of your help!) is to explicitly drop the current embedding dimension from the cross filter, IF `graphSelection.selection.mode === "all"`

Proof that subsetting in one embedding will keep the subset when switching to a different embedding (a bug Seve found from the previous solution):


https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/23b04a0f-ce56-42cf-9783-bca1349f52c0

