### PR TITLE
feat: Bump max zoom from 12 to 80

### DIFF
--- a/client/src/util/constants.ts
+++ b/client/src/util/constants.ts
@@ -4,4 +4,4 @@
  */
 export const THROTTLE_MS = 16;
 
-export const SCALE_MAX = 12.0;
+export const SCALE_MAX = 80.0;


### PR DESCRIPTION
Talked to Nik and we think setting 80 as the new max is reasonable

zoom level 12: <-------- CURRENT MAX

<img width="1728" alt="Screenshot 2024-06-03 at 12 27 25 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/9f129d1e-07e7-43a1-bb4f-4819af519899">

zoom level 40:
<img width="1728" alt="Screenshot 2024-06-03 at 12 04 37 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/47683931-1a63-4fdf-bdc6-4dca55e0304b">

zoom level 50:
<img width="1728" alt="Screenshot 2024-06-03 at 12 04 44 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/e999d274-fe5c-40ec-b617-cf4dfe526e7c">

zoom level 60:
<img width="1728" alt="Screenshot 2024-06-03 at 12 04 54 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/4641eeeb-7c6b-4a92-b5dc-fc1d7a492d8e">

zoom level 70:
<img width="1728" alt="Screenshot 2024-06-03 at 12 05 03 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/17088f36-0546-479e-b367-8ad29f3578be">

zoom level 80: <-- NEW MAX
<img width="1728" alt="Screenshot 2024-06-03 at 12 05 12 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/ad1b7c1b-623b-4a66-a3a2-116fa034fe72">

zoom level 90:
<img width="1728" alt="Screenshot 2024-06-03 at 12 05 21 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/4ac7de21-e2e3-43c4-8638-e0275683118a">

zoom level 100:
<img width="1728" alt="Screenshot 2024-06-03 at 12 05 29 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/7e2125ff-1c48-44fc-bb14-72aca35f639e">
