### PR TITLE
fix: empty object triggers spatial normalization

### DIFF
--- a/server/dataset/dataset.py
+++ b/server/dataset/dataset.py
@@ -346,7 +346,7 @@ class Dataset(metaclass=ABCMeta):
         Embedding is an ndarray, shape (n_obs, n)., where n is normally 2
         """
 
-        if spatial is not None and ename in "spatial":
+        if spatial and ename in "spatial":
 
             library_id = list(spatial.keys())[0]
             image_properties = spatial[library_id]["image_properties"]


### PR DESCRIPTION
This fixes the HTTP error thrown when navigating to aggregated datasets spatial embedding in explorer
<img width="1913" alt="Screenshot 2024-06-11 at 9 25 50 PM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/7976579/e5858194-a9e5-4048-b3d1-77608cd7ac38">
