### PR TITLE
chore: enforce conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,19 @@
+# Validates PR title follows conventional commits
+name: conventional-commits
+on:
+  pull_request:
+    branches: main
+    types:
+      - edited
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  conventional_commit_title:
+    runs-on: [ARM64, self-hosted, Linux]
+    steps:
+      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.4.0

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -1,5 +1,5 @@
 services:
   explorer:
     image:
-      tag: sha-95abe1f7
+      tag: sha-6a4bee02
     replicaCount: 1


### PR DESCRIPTION
Adds a CI job to enforce that PR titles use conventional commit messages in support for Argus + release-please. This ensures that release-please includes changes in the release PRs for Argus

Ref: 
- https://github.com/googleapis/release-please?tab=readme-ov-file#release-please
- https://www.conventionalcommits.org/en/v1.0.0/