### PR TITLE
fix: 1001 No download image for minimized panel

### DIFF
--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -70,6 +70,7 @@ import {
   toggleSidePanel,
 } from "../util/helpers";
 import { SCALE_MAX } from "../../src/util/constants";
+import { PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID } from "../../src/components/PanelEmbedding/constants";
 
 const { describe, skip } = test;
 
@@ -1467,7 +1468,38 @@ for (const testDataset of testDatasets) {
 
             await downloadAndSnapshotImage(page, testInfo);
           });
+
+          test("with side panel", async ({ page }) => {
+            await goToPage(page, url);
+
+            await toggleSidePanel(page);
+
+            const downloads: Download[] = [];
+
+            page.on("download", (downloadData) => {
+              downloads.push(downloadData);
+            });
+
+            await page.getByTestId("download-graph-button").click();
+
+            expect(downloads.length).toBe(2);
+
+            const afterMinimizeDownloads: Download[] = [];
+
+            await page
+              .getByTestId(PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID)
+              .click();
+
+            page.on("download", (downloadData) => {
+              afterMinimizeDownloads.push(downloadData);
+            });
+
+            await page.getByTestId("download-graph-button").click();
+
+            expect(afterMinimizeDownloads.length).toBe(1);
+          });
         });
+
         describeFn("Side Panel", () => {
           test("open and close side panel", async ({ page }, testInfo) => {
             await goToPage(page, url);

--- a/client/__tests__/util/helpers.ts
+++ b/client/__tests__/util/helpers.ts
@@ -288,10 +288,7 @@ export async function conditionallyToggleSidePanel(
 }
 
 export function skipIfSidePanel(graphTestId: string, MAIN_PANEL: string) {
-  const message = "This test is only for the main panel";
-  if (graphTestId !== MAIN_PANEL) {
-    skip(true, message);
-  }
+  skip(graphTestId !== MAIN_PANEL, "This test is only for the main panel");
 }
 
 export function shouldSkipTests(

--- a/client/src/components/PanelEmbedding/constants.ts
+++ b/client/src/components/PanelEmbedding/constants.ts
@@ -1,0 +1,2 @@
+export const PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID =
+  "panel-embedding-minimize-toggle";

--- a/client/src/components/PanelEmbedding/index.tsx
+++ b/client/src/components/PanelEmbedding/index.tsx
@@ -10,6 +10,7 @@ import Controls from "../controls";
 import Embedding from "../embedding";
 import { AppDispatch, RootState } from "../../reducers";
 import actions from "../../actions";
+import { PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID } from "./constants";
 
 interface StateProps {
   isMinimized: boolean;
@@ -94,6 +95,7 @@ const PanelEmbedding = (props: StateProps & DispatchProps) => {
           >
             <Button
               type="button"
+              data-testid={PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID}
               icon={isMinimized ? IconNames.MAXIMIZE : IconNames.MINIMIZE}
               onClick={() => {
                 dispatch({

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -47,6 +47,7 @@ import {
   getSpatialPrefixUrl,
   getSpatialTileSources,
   loadImage,
+  shouldSkipSidePanelImage,
   sidePanelAttributeNameChange,
 } from "./util";
 
@@ -85,6 +86,7 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => ({
   imageUnderlay: state.controls.imageUnderlay,
   config: state.config,
   isSidePanelOpen: state.panelEmbedding.open,
+  isSidePanelMinimized: state.panelEmbedding.minimized,
   sidePanelLayoutChoice: state.panelEmbedding.layoutChoice,
 });
 
@@ -561,9 +563,16 @@ class Graph extends React.Component<GraphProps, GraphState> {
       isSidePanelOpen,
       sidePanelLayoutChoice,
       isSidePanel,
+      isSidePanelMinimized,
     } = this.props;
 
-    if (!this.reglCanvas || !screenCap || !regl || this.isDownloadingImage) {
+    if (
+      !this.reglCanvas ||
+      !screenCap ||
+      !regl ||
+      this.isDownloadingImage ||
+      shouldSkipSidePanelImage(this.props)
+    ) {
       return;
     }
 
@@ -655,7 +664,7 @@ class Graph extends React.Component<GraphProps, GraphState> {
         if (!isSidePanel) {
           track(
             EVENTS.EXPLORER_DOWNLOAD_COMPLETE,
-            isSidePanelOpen
+            isSidePanelOpen && !isSidePanelMinimized
               ? {
                   embedding: layoutChoice.current,
                   side_by_side: sidePanelLayoutChoice?.current,

--- a/client/src/components/graph/types.ts
+++ b/client/src/components/graph/types.ts
@@ -8,7 +8,7 @@ import { Camera } from "../../util/camera";
 
 import { Dataframe } from "../../util/dataframe";
 
-import { LassoFunctionWithAttributes } from "./setupLasso";
+import { type LassoFunctionWithAttributes } from "./setupLasso";
 
 import { AppDispatch, RootState } from "../../reducers";
 
@@ -60,6 +60,7 @@ export interface StateProps {
   imageUnderlay: RootState["controls"]["imageUnderlay"];
   config: RootState["config"];
   isSidePanelOpen: RootState["panelEmbedding"]["open"];
+  isSidePanelMinimized: RootState["panelEmbedding"]["minimized"];
   sidePanelLayoutChoice: RootState["panelEmbedding"]["layoutChoice"];
 }
 

--- a/client/src/components/graph/util.ts
+++ b/client/src/components/graph/util.ts
@@ -1,6 +1,7 @@
 import { mat3 } from "gl-matrix";
 import { toPng } from "html-to-image";
 import { LayoutChoiceState } from "../../reducers/layoutChoice";
+import { GraphProps } from "./types";
 
 export function sidePanelAttributeNameChange(
   name: string,
@@ -207,4 +208,15 @@ export function downloadImage(
     URL.revokeObjectURL(imageURI);
     a.remove();
   }, 1000);
+}
+
+/**
+ * (thuang): Product requirement that the side panel should NOT be included
+ * in the download when it's minimized
+ */
+export function shouldSkipSidePanelImage({
+  isSidePanel,
+  isSidePanelMinimized,
+}: GraphProps) {
+  return isSidePanel && isSidePanelMinimized;
 }


### PR DESCRIPTION
closes #1001

1. This PR addresses the comment by @ainfeld and @niknak33 that when the side panel is open BUT minimized, we should not download its image ([slack](https://chanzuckerbergteam.slack.com/archives/C0743HLEWMC/p1718918988252109?thread_ts=1718907751.998779&cid=C0743HLEWMC))