### PR TITLE
chore: bump staging memory

### DIFF
--- a/.infra/staging/values.yaml
+++ b/.infra/staging/values.yaml
@@ -10,7 +10,7 @@ stack:
       resources:
         limits:
           cpu: 4
-          memory: 14Gi
+          memory: 16Gi
         requests:
           cpu: 2
           memory: 4Gi

--- a/.infra/staging/values.yaml
+++ b/.infra/staging/values.yaml
@@ -10,10 +10,10 @@ stack:
       resources:
         limits:
           cpu: 4
-          memory: 16Gi
+          memory: 24Gi
         requests:
           cpu: 2
-          memory: 4Gi
+          memory: 8Gi
       env:
         # env vars common to all deployment stages
         - name: AWS_REGION


### PR DESCRIPTION
Bump memory limit for staging stack to prevent 137 exit codes from Kubernetes