### PR TITLE
chore: Update conventional commit GHA

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,4 +16,4 @@ jobs:
   conventional_commit_title:
     runs-on: [ARM64, self-hosted, Linux]
     steps:
-      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.4.0
+      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.5.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,11 @@
   "bump-minor-pre-major": true,
   "changelog-sections": [
     {
+      "type": "chore",
+      "section": "Misc",
+      "hidden": false
+    },
+    {
       "type": "feat",
       "section": "Features",
       "hidden": false
@@ -14,8 +19,43 @@
       "hidden": false
     },
     {
-      "type": "chore",
-      "section": "Misc",
+      "type": "deps",
+      "section": "Dependencies",
+      "hidden": false
+    },
+    {
+      "type": "revert",
+      "section": "Reverts",
+      "hidden": false
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": false
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": false
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": false
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements",
+      "hidden": false
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
       "hidden": false
     }
   ],


### PR DESCRIPTION
Upgrade to use to get more conventional commit types: https://github.com/chanzuckerberg/github-actions/pull/279
Also update release-please to recognize the additional types