### PR TITLE
feat: limit zoom level for hires

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-ad1cd6da
+        tag: sha-31079fcd
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-31079fcd
+        tag: sha-0687c8f9
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-0687c8f9
+        tag: sha-51349b9c
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -69,7 +69,7 @@ import {
   skipIfSidePanel,
   toggleSidePanel,
 } from "../util/helpers";
-import { SCALE_MAX } from "../../src/util/constants";
+import { SCALE_MAX_HIRES } from "../../src/util/constants";
 import { PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID } from "../../src/components/PanelEmbedding/constants";
 
 const { describe, skip } = test;
@@ -759,7 +759,7 @@ for (const testDataset of testDatasets) {
               const newGraph = page.getByTestId("graph-wrapper");
               const newDistance =
                 (await newGraph.getAttribute("data-camera-distance")) ?? "-1";
-              expect(parseFloat(newDistance)).toBe(SCALE_MAX);
+              expect(parseFloat(newDistance)).toBe(SCALE_MAX_HIRES);
             },
             { page }
           );

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -729,7 +729,7 @@ for (const testDataset of testDatasets) {
           });
         });
 
-        test("zoom limit is 12x", async ({ page }, testInfo) => {
+        test.only("zoom limit is 12x", async ({ page }, testInfo) => {
           await goToPage(page, url);
           const category = Object.keys(
             data.categorical

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -729,7 +729,7 @@ for (const testDataset of testDatasets) {
           });
         });
 
-        test.only("zoom limit is 12x", async ({ page }, testInfo) => {
+        test("zoom limit is 12x", async ({ page }, testInfo) => {
           await goToPage(page, url);
           const category = Object.keys(
             data.categorical

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -94,7 +94,10 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => ({
 });
 
 class Graph extends React.Component<GraphProps, GraphState> {
-  static createReglState(canvas: HTMLCanvasElement): {
+  static createReglState(
+    canvas: HTMLCanvasElement,
+    resolution: string
+  ): {
     camera: Camera;
     regl: Regl;
     drawPoints: DrawCommand;
@@ -106,7 +109,7 @@ class Graph extends React.Component<GraphProps, GraphState> {
         Must be created for each canvas
         */
     // setup canvas, webgl draw function and camera
-    const camera = _camera(canvas);
+    const camera = _camera(canvas, resolution);
     const regl = _regl(canvas);
     const drawPoints = _drawPoints(regl);
 
@@ -710,8 +713,10 @@ class Graph extends React.Component<GraphProps, GraphState> {
       return;
     }
     this.reglCanvas = canvas;
+    const { unsMetadata } = this.props;
+    const { resolution } = unsMetadata;
     this.setState({
-      ...Graph.createReglState(canvas),
+      ...Graph.createReglState(canvas, resolution),
     });
   };
 

--- a/client/src/util/camera.ts
+++ b/client/src/util/camera.ts
@@ -3,7 +3,7 @@ import { MouseEvent } from "react";
 import { Point, Viewer } from "openseadragon";
 import { debounce } from "lodash";
 import clamp from "./clamp";
-import { THROTTLE_MS, SCALE_MAX } from "./constants";
+import { THROTTLE_MS, SCALE_MAX, SCALE_MAX_HIRES } from "./constants";
 import { EVENTS } from "../analytics/events";
 import { track } from "../analytics";
 
@@ -24,6 +24,8 @@ const scratch3 = new Float32Array(16);
 export class Camera {
   canvas: HTMLCanvasElement;
 
+  resolution: string;
+
   prevEvent: {
     clientX: number;
     clientY: number;
@@ -34,13 +36,14 @@ export class Camera {
 
   viewMatrixInv: mat3;
 
-  constructor(canvas: HTMLCanvasElement) {
+  constructor(canvas: HTMLCanvasElement, resolution: string) {
     this.prevEvent = {
       clientX: 0,
       clientY: 0,
       type: "",
     };
     this.canvas = canvas;
+    this.resolution = resolution;
     this.viewMatrix = mat3.create();
     this.viewMatrixInv = mat3.create();
   }
@@ -180,7 +183,9 @@ export class Camera {
     const xClamped = clamp(x, bounds);
     const yClamped = clamp(y, bounds);
 
-    const dClamped = clamp(d * m[0], [scaleMin, SCALE_MAX]) / m[0];
+    const scaleMax = this.resolution === "hires" ? SCALE_MAX_HIRES : SCALE_MAX;
+
+    const dClamped = clamp(d * m[0], [scaleMin, scaleMax]) / m[0];
 
     if (Math.abs(1 - dClamped) <= EPSILON) return; // noop request
 
@@ -372,8 +377,8 @@ export class Camera {
   }
 }
 
-function attachCamera(canvas: HTMLCanvasElement): Camera {
-  return new Camera(canvas);
+function attachCamera(canvas: HTMLCanvasElement, resolution: string): Camera {
+  return new Camera(canvas, resolution);
 }
 
 function openseadragonPan({

--- a/client/src/util/camera.ts
+++ b/client/src/util/camera.ts
@@ -183,7 +183,10 @@ export class Camera {
     const xClamped = clamp(x, bounds);
     const yClamped = clamp(y, bounds);
 
-    const scaleMax = this.resolution === "hires" ? SCALE_MAX_HIRES : SCALE_MAX;
+    const scaleMax =
+      this.resolution === "hires" || this.resolution === ""
+        ? SCALE_MAX_HIRES
+        : SCALE_MAX;
 
     const dClamped = clamp(d * m[0], [scaleMin, scaleMax]) / m[0];
 

--- a/client/src/util/constants.ts
+++ b/client/src/util/constants.ts
@@ -6,6 +6,8 @@ export const THROTTLE_MS = 16;
 
 export const SCALE_MAX = 80.0;
 
+export const SCALE_MAX_HIRES = 12.0;
+
 export const LAYOUT_CHOICE_TEST_ID = "layout-choice";
 
 export const GRAPH_AS_IMAGE_TEST_ID = "capture-and-display-graph";

--- a/client/src/util/glHelpers.ts
+++ b/client/src/util/glHelpers.ts
@@ -47,7 +47,7 @@ export const glPointFlags = `
     flag = shiftRightOne(flag);
     isHighlight = isLowBitSet(flag);
   }
-    
+
 `;
 
 /*
@@ -83,5 +83,31 @@ export const glPointSize = `
     if (isHighlight) return 2. * pointSize;
     if (isSelected) return pointSize;
     return pointSize / 3.;
+  }
+`;
+
+export const densityFactor = 0.9;
+
+export const glPointSizeSpatial = `
+
+  float pointSizeSpatial(float nPoints, float minViewportDimension, bool isSelected, bool isHighlight, float distance, float imageHeight, float scaleref, float spotDiameterFullres) {
+    
+    float scaleFactor = (minViewportDimension / imageHeight) ;
+
+
+    // Adjust base size based on distance (zoom level)
+    float adjustedDistance = clamp(distance, 1., 3.5); // Clamp the distance to avoid extreme values
+    float zoomFactor = 1.0 / adjustedDistance * distance * ${densityFactor}; // Inverse of adjustedDistance and multiply by distnace and density factor to get smoother dot size change
+    float adjustedZoomFactor = clamp(zoomFactor, 0.5, 3.5); // Clamp the zoom factor to avoid extreme values and overlapping dots
+
+    float baseSize = spotDiameterFullres * scaleref * scaleFactor * adjustedZoomFactor; // Base size proportional to viewport
+    
+    if (isSelected) {
+      return baseSize * 1.5; // Increase size if selected
+    } else if (isHighlight) {
+      return baseSize * 2.0; // Increase size if highlighted
+    } else {
+      return baseSize;
+    }
   }
 `;

--- a/client/src/util/glHelpers.ts
+++ b/client/src/util/glHelpers.ts
@@ -47,7 +47,7 @@ export const glPointFlags = `
     flag = shiftRightOne(flag);
     isHighlight = isLowBitSet(flag);
   }
-
+    
 `;
 
 /*
@@ -83,31 +83,5 @@ export const glPointSize = `
     if (isHighlight) return 2. * pointSize;
     if (isSelected) return pointSize;
     return pointSize / 3.;
-  }
-`;
-
-export const densityFactor = 0.9;
-
-export const glPointSizeSpatial = `
-
-  float pointSizeSpatial(float nPoints, float minViewportDimension, bool isSelected, bool isHighlight, float distance, float imageHeight, float scaleref, float spotDiameterFullres) {
-    
-    float scaleFactor = (minViewportDimension / imageHeight) ;
-
-
-    // Adjust base size based on distance (zoom level)
-    float adjustedDistance = clamp(distance, 1., 3.5); // Clamp the distance to avoid extreme values
-    float zoomFactor = 1.0 / adjustedDistance * distance * ${densityFactor}; // Inverse of adjustedDistance and multiply by distnace and density factor to get smoother dot size change
-    float adjustedZoomFactor = clamp(zoomFactor, 0.5, 3.5); // Clamp the zoom factor to avoid extreme values and overlapping dots
-
-    float baseSize = spotDiameterFullres * scaleref * scaleFactor * adjustedZoomFactor; // Base size proportional to viewport
-    
-    if (isSelected) {
-      return baseSize * 1.5; // Increase size if selected
-    } else if (isHighlight) {
-      return baseSize * 2.0; // Increase size if highlighted
-    } else {
-      return baseSize;
-    }
   }
 `;


### PR DESCRIPTION
Added condition in `camera` to limit zoom level for `hires` to 12.0 - otherwise default to SCALE_MAX value (80.0)