### PR TITLE
feat: 6867 6868 image and dot opacity

### DIFF
--- a/.github/workflows/workflow-argus-docker-build.yaml
+++ b/.github/workflows/workflow-argus-docker-build.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   argus_builder:
-    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v2.9.0
+    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v2.11.1
     secrets: inherit
     with:
       branches: ${{ inputs.branches }}

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-7a1f4e0e
+        tag: sha-01db94ac
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -857,7 +857,7 @@ export async function selectLayout(
     }
   }
 
-  await page.getByTestId(layoutChoiceTestId).click();
+  await page.getByTestId(layoutChoiceTestId).click({ force: true });
 
   await page.waitForTimeout(WAIT_FOR_SWITCH_LAYOUT_MS);
 }

--- a/client/__tests__/e2e/cellxgeneActions.ts
+++ b/client/__tests__/e2e/cellxgeneActions.ts
@@ -821,7 +821,7 @@ export async function selectLayout(
     layoutChoiceTestId = `${LAYOUT_CHOICE_TEST_ID}-side`;
   }
 
-  await page.getByTestId(layoutChoiceTestId).click();
+  await page.getByTestId(layoutChoiceTestId).click({ force: true });
 
   /**
    * (thuang): For blueprint radio buttons, we need to tab first to go to the

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -1520,9 +1520,21 @@ for (const testDataset of testDatasets) {
 
             const afterMinimizeDownloads: Download[] = [];
 
-            await page
-              .getByTestId(PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID)
-              .click();
+            await tryUntil(
+              async () => {
+                await page
+                  .getByTestId(PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID)
+                  .click();
+
+                /**
+                 * (thuang): Make sure the side panel is indeed minimized
+                 */
+                await expect(
+                  page.getByTestId("graph-wrapper-side")
+                ).not.toBeVisible();
+              },
+              { page }
+            );
 
             page.on("download", (downloadData) => {
               afterMinimizeDownloads.push(downloadData);

--- a/client/src/components/NavBar/index.tsx
+++ b/client/src/components/NavBar/index.tsx
@@ -132,6 +132,7 @@ const Header = (props: HeaderProps) => {
         <Right>
           <LinkWrapper>
             <Popover2
+              hasBackdrop
               content={
                 <Menu>
                   <MenuItem

--- a/client/src/components/continuousLegend/index.tsx
+++ b/client/src/components/continuousLegend/index.tsx
@@ -15,6 +15,12 @@ import {
 import { ColorsState } from "../../reducers/colors";
 import { Genesets } from "../../reducers/genesets";
 import * as globals from "../../globals";
+
+/**
+ * (thuang): The legend needs to be positioned below the cell count element
+ */
+const CELL_COUNT_ELEMENT_HEIGHT_PX = 20;
+
 // create continuous color legend
 const continuous = (selectorId: any, colorScale: any, colorAccessor: any) => {
   const legendHeight = 200;
@@ -237,7 +243,7 @@ class ContinuousLegend extends React.Component<Props> {
         style={{
           position: "absolute",
           left: 8,
-          top: 35,
+          top: CELL_COUNT_ELEMENT_HEIGHT_PX + 35,
           zIndex: 1,
           pointerEvents: "none",
         }}

--- a/client/src/components/embedding/components/Opacities/components/Opacity/index.tsx
+++ b/client/src/components/embedding/components/Opacities/components/Opacity/index.tsx
@@ -1,0 +1,80 @@
+import React, { ChangeEvent } from "react";
+import { InputSlider } from "czifui";
+import { SliderProps } from "@material-ui/core";
+
+import { kebabCase } from "lodash";
+import {
+  HeaderWrapper,
+  InputTextWrapper,
+  Mark,
+  Percentage,
+  StyledInputText,
+  Title,
+} from "./style";
+
+const MARKS = [
+  {
+    value: 0,
+    label: <Mark>0</Mark>,
+  },
+  {
+    value: 50,
+    label: <Mark>50</Mark>,
+  },
+  {
+    value: 100,
+    label: <Mark>100</Mark>,
+  },
+];
+
+interface Props {
+  name: string;
+  value: number;
+  handleChange: (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    value: number | number[]
+  ) => void;
+}
+
+export default function Opacity({ name, value, handleChange }: Props) {
+  const kebabName = kebabCase(name);
+
+  return (
+    <>
+      <HeaderWrapper>
+        <Title>{name}</Title>
+        <InputTextWrapper>
+          <StyledInputText
+            id={kebabName}
+            data-testid={`${kebabName}-input`}
+            label={name}
+            hideLabel
+            sdsType="textField"
+            value={value}
+            onChange={(event) => {
+              handleChange(event, Number(event.target.value));
+            }}
+            type="number"
+            inputProps={{
+              min: 0,
+              max: 100,
+              "aria-labelledby": "image-opacity-label",
+              "aria-label": "Image Opacity",
+            }}
+          />
+          <Percentage>%</Percentage>
+        </InputTextWrapper>
+      </HeaderWrapper>
+
+      <InputSlider
+        data-testid={`${kebabName}-slider`}
+        marks={MARKS}
+        value={value}
+        step={10}
+        min={0}
+        max={100}
+        onChange={handleChange as SliderProps["onChange"]}
+      />
+    </>
+  );
+}

--- a/client/src/components/embedding/components/Opacities/components/Opacity/style.ts
+++ b/client/src/components/embedding/components/Opacities/components/Opacity/style.ts
@@ -1,0 +1,58 @@
+import styled from "@emotion/styled";
+import { InputText } from "czifui";
+import {
+  fontWeightBold,
+  spacesM,
+  spacesS,
+  spacesXs,
+  textSecondary,
+} from "../../../../../theme";
+
+export const Mark = styled.span`
+  color: ${textSecondary};
+`;
+
+export const HeaderWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const InputTextWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  position: relative;
+`;
+
+export const StyledInputText = styled(InputText)`
+  min-width: 10px;
+  padding: ${spacesXs}px ${spacesM}px;
+  margin: 0;
+  padding: 0;
+
+  /* Chrome, Safari, Edge, Opera remove up/down arrow */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox remove up/down arrow */
+  input[type="number"] {
+    -moz-appearance: textfield;
+  }
+
+  input {
+    width: 60px;
+    margin-left: -6px;
+  }
+`;
+
+export const Percentage = styled.span`
+  position: absolute;
+  right: ${spacesS}px;
+`;
+
+export const Title = styled.div`
+  font-weight: ${fontWeightBold};
+`;

--- a/client/src/components/embedding/components/Opacities/index.tsx
+++ b/client/src/components/embedding/components/Opacities/index.tsx
@@ -1,0 +1,59 @@
+import React, { ChangeEvent } from "react";
+
+import { connect } from "react-redux";
+import { Section, Wrapper } from "./style";
+import Opacity from "./components/Opacity";
+import { RootState } from "../../../../reducers";
+import { Props, StateProps } from "./types";
+
+function Opacities({ imageOpacity, dotOpacity, dispatch }: Props) {
+  return (
+    <Wrapper>
+      <Section>
+        <Opacity
+          name="Image Opacity"
+          value={imageOpacity}
+          handleChange={handleImageOpacityChange}
+        />
+      </Section>
+      <Section>
+        <Opacity
+          name="Dot Opacity"
+          value={dotOpacity}
+          handleChange={handleDotOpacityChange}
+        />
+      </Section>
+    </Wrapper>
+  );
+
+  function handleImageOpacityChange(
+    _: ChangeEvent<unknown>,
+    value: number | number[]
+  ) {
+    dispatch({
+      type: "set image opacity",
+      data: value,
+    });
+  }
+
+  function handleDotOpacityChange(
+    _: ChangeEvent<unknown>,
+    value: number | number[]
+  ) {
+    dispatch({
+      type: "set dot opacity",
+      data: value,
+    });
+  }
+}
+
+function mapStateToProps({ controls }: RootState): StateProps {
+  const { imageOpacity, dotOpacity } = controls;
+
+  return {
+    imageOpacity,
+    dotOpacity,
+  };
+}
+
+export default connect(mapStateToProps)(Opacities);

--- a/client/src/components/embedding/components/Opacities/style.ts
+++ b/client/src/components/embedding/components/Opacities/style.ts
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+import { spacesM, spacesS } from "../../../theme";
+
+export const Wrapper = styled.div`
+  padding: ${spacesS}px ${spacesM}px;
+  width: 250px;
+  height: 200px;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+`;
+
+export const Section = styled.div`
+  padding: 0 ${spacesS}px;
+`;

--- a/client/src/components/embedding/components/Opacities/types.ts
+++ b/client/src/components/embedding/components/Opacities/types.ts
@@ -1,0 +1,12 @@
+import { AppDispatch, RootState } from "../../../../reducers";
+
+export type Props = StateProps & DispatchProps;
+
+export interface StateProps {
+  imageOpacity: RootState["controls"]["imageOpacity"];
+  dotOpacity: RootState["controls"]["dotOpacity"];
+}
+
+interface DispatchProps {
+  dispatch: AppDispatch;
+}

--- a/client/src/components/embedding/style.ts
+++ b/client/src/components/embedding/style.ts
@@ -1,0 +1,12 @@
+import { Button } from "@blueprintjs/core";
+import styled from "@emotion/styled";
+
+export const ImageToggleWrapper = styled.span`
+  margin-left: 8px;
+  display: flex;
+`;
+
+export const ImageDropdownButton = styled(Button)`
+  /* (thuang): Make the caret button narrower */
+  min-width: 10px;
+`;

--- a/client/src/components/graph/types.ts
+++ b/client/src/components/graph/types.ts
@@ -63,6 +63,8 @@ export interface StateProps {
   isSidePanelMinimized: RootState["panelEmbedding"]["minimized"];
   sidePanelLayoutChoice: RootState["panelEmbedding"]["layoutChoice"];
   unsMetadata: RootState["controls"]["unsMetadata"];
+  imageOpacity: RootState["controls"]["imageOpacity"];
+  dotOpacity: RootState["controls"]["dotOpacity"];
 }
 
 export interface OwnProps {

--- a/client/src/components/menubar/index.tsx
+++ b/client/src/components/menubar/index.tsx
@@ -17,7 +17,6 @@ import { EVENTS } from "../../analytics/events";
 import Embedding from "../embedding";
 import { getFeatureFlag } from "../../util/featureFlags/featureFlags";
 import { FEATURES } from "../../util/featureFlags/features";
-import { shouldShowOpenseadragon } from "../../common/selectors";
 import { GRAPH_AS_IMAGE_TEST_ID } from "../../util/constants";
 import { AppDispatch, RootState } from "../../reducers";
 import { AnnoMatrixClipView } from "../../annoMatrix/views";
@@ -33,13 +32,6 @@ interface StateProps {
   showCentroidLabels: RootState["centroidLabels"]["showLabels"];
   categoricalSelection: RootState["categoricalSelection"];
   screenCap: RootState["controls"]["screenCap"];
-  imageUnderlay: RootState["controls"]["imageUnderlay"];
-  // eslint-disable-next-line react/no-unused-prop-types -- used in shouldShowOpenseadragon
-  layoutChoice: RootState["layoutChoice"];
-  // eslint-disable-next-line react/no-unused-prop-types -- used in shouldShowOpenseadragon
-  config: RootState["config"];
-  // eslint-disable-next-line react/no-unused-prop-types -- used in shouldShowOpenseadragon
-  panelEmbedding: RootState["panelEmbedding"];
 }
 
 const mapStateToProps = (state: RootState): StateProps => {
@@ -60,7 +52,6 @@ const mapStateToProps = (state: RootState): StateProps => {
   return {
     subsetPossible,
     subsetResetPossible,
-    config: state.config,
     graphInteractionMode: state.controls.graphInteractionMode,
     clipPercentileMin: Math.round(100 * clipRangeMin),
     clipPercentileMax: Math.round(100 * clipRangeMax),
@@ -69,9 +60,6 @@ const mapStateToProps = (state: RootState): StateProps => {
     showCentroidLabels: state.centroidLabels.showLabels,
     categoricalSelection: state.categoricalSelection,
     screenCap: state.controls.screenCap,
-    imageUnderlay: state.controls.imageUnderlay,
-    layoutChoice: state.layoutChoice,
-    panelEmbedding: state.panelEmbedding,
   };
 };
 
@@ -269,7 +257,6 @@ class MenuBar extends React.PureComponent<MenuBarProps, State> {
       subsetPossible,
       subsetResetPossible,
       screenCap,
-      imageUnderlay,
     } = this.props;
     const { pendingClipPercentiles } = this.state;
 
@@ -398,38 +385,6 @@ class MenuBar extends React.PureComponent<MenuBarProps, State> {
               disabled={!isColoredByCategorical}
             />
           </Tooltip>
-          {shouldShowOpenseadragon(this.props) && (
-            <ButtonGroup className={styles.menubarButton}>
-              <Tooltip
-                content="Toggle image"
-                position="bottom"
-                hoverOpenDelay={globals.tooltipHoverOpenDelay}
-              >
-                <AnchorButton
-                  type="button"
-                  data-testid="toggle-image-underlay"
-                  icon="media"
-                  intent={imageUnderlay ? "primary" : "none"}
-                  active={imageUnderlay}
-                  onClick={() => {
-                    track(
-                      /**
-                       * (thuang): If `imageUnderlay` is currently `true`, then
-                       * we're about to deselect it thus firing the deselection event.
-                       */
-                      imageUnderlay
-                        ? EVENTS.EXPLORER_IMAGE_DESELECT
-                        : EVENTS.EXPLORER_IMAGE_SELECT
-                    );
-                    dispatch({
-                      type: "toggle image underlay",
-                      toggle: !imageUnderlay,
-                    });
-                  }}
-                />
-              </Tooltip>
-            </ButtonGroup>
-          )}
           <ButtonGroup className={styles.menubarButton}>
             <Tooltip
               content={selectionTooltip}

--- a/client/src/reducers/controls.ts
+++ b/client/src/reducers/controls.ts
@@ -32,6 +32,8 @@ interface ControlsState {
   infoPanelHidden: boolean;
   infoPanelMinimized: boolean;
   unsMetadata: DatasetUnsMetadata;
+  imageOpacity: number;
+  dotOpacity: number;
 }
 const Controls = (
   state: ControlsState = {
@@ -69,6 +71,8 @@ const Controls = (
       scaleref: 0.1868635,
       spotDiameterFullres: 86.06629150338271,
     },
+    imageOpacity: 100,
+    dotOpacity: 100,
   },
   action: AnyAction
 ): ControlsState => {
@@ -297,6 +301,21 @@ const Controls = (
         ...state,
         loading: false,
         error: action.error,
+      };
+    }
+    /**************************
+         Opacities
+    **************************/
+    case "set image opacity": {
+      return {
+        ...state,
+        imageOpacity: action.data,
+      };
+    }
+    case "set dot opacity": {
+      return {
+        ...state,
+        dotOpacity: action.data,
       };
     }
     default:


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>Name</th>
      <td>thuang-6867-image-dot-opacity</td>
    </tr>
    <tr>
      <th>Short Name</th>
      <td>unbiased-glowworm</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://unbiased-glowworm.dev-sc.dev.czi.team" target="_blank">https://unbiased-glowworm.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>
<!--ARGUS_STACK_DETAILS_END:do not remove this marker as it will break the argus metadata functionality-->

---

1. Add `Opacities` component to control both image and dots opacity
2. Move Image Toggle button to the left side as part of the `Embedding` component

***KNOWN ISSUES***
1. The opacity control is persistent across different embedding types and shared between main and side panels
2. For example, if you set dot opacity to 50% and switch embedding to a non-spatial one, the dots will still be at 50% opacity
    - <img width="1244" alt="Screenshot 2024-07-09 at 10 26 43 AM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/00fccf46-237e-4a87-925c-42b6a060a75f">

Screenshots:

1. <img width="1112" alt="Screenshot 2024-07-09 at 10 26 19 AM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/89281c10-21a0-46ba-bc79-10b398bc722d">
2. <img width="1232" alt="Screenshot 2024-07-09 at 10 26 26 AM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/a5280955-b0c3-44b6-95a8-c38925abd47a">
3. <img width="1513" alt="Screenshot 2024-07-09 at 10 26 33 AM" src="https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/949798ea-6856-4db9-9454-362880d91e7a">

Video:

https://github.com/chanzuckerberg/single-cell-explorer/assets/6309723/22235e0b-cb9b-415f-84ed-a7506522b17f

