### PR TITLE
fix: Remove the wrong lasso in the other panel

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-26c7759a
+        tag: sha-d2193663
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -73,6 +73,7 @@ import { SCALE_MAX_HIRES } from "../../src/util/constants";
 import { PANEL_EMBEDDING_MINIMIZE_TOGGLE_TEST_ID } from "../../src/components/PanelEmbedding/constants";
 import { CONTINUOUS_SECTION_TEST_ID } from "../../src/components/continuous/constants";
 import { CATEGORICAL_SECTION_TEST_ID } from "../../src/components/categorical/constants";
+import { sidePanelAttributeNameChange } from "../../src/components/graph/util";
 
 const { describe, skip } = test;
 
@@ -126,6 +127,8 @@ for (const testDataset of testDatasets) {
   const data = datasets[testDataset];
   const url = testURLs[testDataset];
   for (const graphTestId of graphInstanceTestIds) {
+    const isSidePanel = graphTestId === SIDE_PANEL;
+
     const shouldSkip = shouldSkipTests(graphTestId, SIDE_PANEL);
     const describeFn = shouldSkip ? describe.skip : describe;
 
@@ -324,8 +327,9 @@ for (const testDataset of testDatasets) {
                 lasso: true,
               });
 
-              const cellCount =
-                graphTestId === SIDE_PANEL ? cellset.count_side : cellset.count;
+              const cellCount = isSidePanel
+                ? cellset.count_side
+                : cellset.count;
 
               expect(await getCellSetCount(1, page)).toBe(cellCount);
 
@@ -812,9 +816,7 @@ for (const testDataset of testDatasets) {
               const panzoomLasso = data.features.panzoom.lasso;
 
               const expectedCellCount = Number(
-                graphTestId === SIDE_PANEL
-                  ? panzoomLasso.count_side
-                  : panzoomLasso.count
+                isSidePanel ? panzoomLasso.count_side : panzoomLasso.count
               );
 
               const lassoSelection = await calcDragCoordinates(
@@ -832,7 +834,11 @@ for (const testDataset of testDatasets) {
                 lasso: true,
               });
 
-              await expect(page.getByTestId("lasso-element")).toBeVisible();
+              await expect(
+                page.getByTestId(
+                  sidePanelAttributeNameChange("lasso-element", isSidePanel)
+                )
+              ).toBeVisible();
 
               const initialCount = Number(await getCellSetCount(1, page));
 
@@ -886,14 +892,16 @@ for (const testDataset of testDatasets) {
 
               await snapshotTestGraph(page, testInfo);
 
-              await expect(page.getByTestId("lasso-element")).toBeVisible();
+              await expect(
+                page.getByTestId(
+                  sidePanelAttributeNameChange("lasso-element", isSidePanel)
+                )
+              ).toBeVisible();
 
               const initialCount = Number(await getCellSetCount(1, page));
 
               const expectedCellCount = Number(
-                graphTestId === SIDE_PANEL
-                  ? panzoomLasso.count_side
-                  : panzoomLasso.count
+                isSidePanel ? panzoomLasso.count_side : panzoomLasso.count
               );
 
               /**

--- a/client/__tests__/util/typedCrossfilter/crossfilter.test.ts
+++ b/client/__tests__/util/typedCrossfilter/crossfilter.test.ts
@@ -446,6 +446,7 @@ describe("ImmutableTypedCrossfilter", () => {
             .select("coords", {
               mode: "within-polygon",
               polygon: polygon as [number, number][],
+              graphId: "test-graph-id",
             })
             .allSelected()
         ).toEqual(

--- a/client/src/actions/selection.ts
+++ b/client/src/actions/selection.ts
@@ -1,5 +1,7 @@
+import { vec2 } from "gl-matrix";
+
 /*
-Action creators for selection 
+Action creators for selection
 */
 export const selectContinuousMetadataAction =
   (
@@ -210,7 +212,15 @@ export const graphLassoDeselectAction = (embName: any) =>
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
 export const graphLassoEndAction =
-  (embName: any, polygon: any) =>
+  ({
+    embName,
+    polygon,
+    graphId,
+  }: {
+    embName: string;
+    polygon: vec2[];
+    graphId: string;
+  }) =>
   async (
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
     dispatch: any,
@@ -233,6 +243,7 @@ export const graphLassoEndAction =
       type: "graph lasso end",
       obsCrossfilter,
       polygon,
+      graphId,
     });
   };
 

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -543,7 +543,7 @@ class Graph extends React.Component<GraphProps, GraphState> {
   // when a lasso is completed, filter to the points within the lasso polygon
   async handleLassoEnd(polygon: [number, number][]): Promise<void> {
     const minimumPolygonArea = 10;
-    const { dispatch, layoutChoice } = this.props;
+    const { dispatch, layoutChoice, isSidePanel } = this.props;
 
     if (
       polygon.length < 3 ||
@@ -553,10 +553,11 @@ class Graph extends React.Component<GraphProps, GraphState> {
       await dispatch(actions.graphLassoDeselectAction(layoutChoice?.current));
     } else {
       await dispatch(
-        actions.graphLassoEndAction(
-          layoutChoice?.current,
-          polygon.map((xy) => this.mapScreenToPoint(xy))
-        )
+        actions.graphLassoEndAction({
+          embName: layoutChoice?.current,
+          polygon: polygon.map((xy) => this.mapScreenToPoint(xy)),
+          graphId: sidePanelAttributeNameChange("graph", Boolean(isSidePanel)),
+        })
       );
     }
   }
@@ -954,14 +955,28 @@ class Graph extends React.Component<GraphProps, GraphState> {
         this is called from componentDidUpdate(), so be very careful using
         anything from this.state, which may be updated asynchronously.
         */
-    const { currentSelection } = this.props;
+    const { currentSelection, isSidePanel } = this.props;
+
     if (currentSelection.mode === "within-polygon") {
-      /*
-            if there is a current selection, make sure the lasso tool matches
-            */
-      const polygon = currentSelection.polygon.map((p: [number, number]) =>
+      const { polygon: polygonState, graphId } = currentSelection;
+
+      /**
+       * (thuang): Only display the lasso element in the panel that initiated
+       * the lasso
+       */
+      if (
+        graphId !== sidePanelAttributeNameChange("graph", Boolean(isSidePanel))
+      ) {
+        return;
+      }
+
+      /**
+       * if there is a current selection, make sure the lasso tool matches
+       */
+      const polygon = polygonState.map((p: [number, number]) =>
         this.mapPointToScreen(p)
       );
+
       tool?.move(polygon);
     } else {
       tool?.reset();

--- a/client/src/components/util/truncate.tsx
+++ b/client/src/components/util/truncate.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement } from "react";
+import React, { CSSProperties, cloneElement } from "react";
 import { Tooltip2 } from "@blueprintjs/popover2";
 
 import { tooltipHoverOpenDelayQuick } from "../../globals";
@@ -19,12 +19,14 @@ const FIRST_HALF_STYLE = {
   whiteSpace: "nowrap",
   flexShrink: 1,
   minWidth: "5px",
-};
+} as CSSProperties;
+
 const SECOND_HALF_STYLE = {
   position: "relative",
   overflow: "hidden",
   whiteSpace: "nowrap",
 };
+
 const SECOND_HALF_SPACING_STYLE = {
   color: "transparent",
 };

--- a/client/src/reducers/graphSelection.ts
+++ b/client/src/reducers/graphSelection.ts
@@ -38,12 +38,13 @@ const GraphSelection = (
     }
 
     case "graph lasso end": {
-      const { polygon } = action;
+      const { polygon, graphId } = action;
       return {
         ...state,
         selection: {
           mode: "within-polygon",
           polygon,
+          graphId,
         },
       };
     }

--- a/client/src/util/typedCrossfilter/types.ts
+++ b/client/src/util/typedCrossfilter/types.ts
@@ -59,6 +59,7 @@ export interface SelectWithinRect {
 export interface SelectWithinPolygon {
   mode: SelectionMode.WithinPolygon | "within-polygon";
   polygon: [number, number][];
+  graphId: string;
 }
 
 export type CrossfilterSelector =


### PR DESCRIPTION
1. Add `graphId` to lasso selection reducer state
2. Use the new `graphId` to determine whether to display the lasso element in the panel or not
3. We only display the lasso element in the panel that initiated the lasso

<img width="1172" alt="Screenshot 2024-07-12 at 12 01 52 PM" src="https://github.com/user-attachments/assets/9454b9ef-ded9-434b-875d-aba512f762f9">

https://github.com/user-attachments/assets/cf2aa442-f862-4151-bccf-10c11bd8de5d

