### PR TITLE
fix: Add mix blend mode to canvas

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-d2193663
+        tag: sha-93a60f26
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/src/components/graph/graph.tsx
+++ b/client/src/components/graph/graph.tsx
@@ -1422,6 +1422,7 @@ class Graph extends React.Component<GraphProps, GraphState> {
             ...COMMON_CANVAS_STYLE,
             shapeRendering: "crispEdges",
             opacity: `${dotOpacity}%`,
+            mixBlendMode: "multiply",
           }}
           id={sidePanelAttributeNameChange(`graph-canvas`, isSidePanel)}
           data-testid={sidePanelAttributeNameChange(


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>Name</th>
      <td>rainandbare-add-mix-blend-mode</td>
    </tr>
    <tr>
      <th>Short Name</th>
      <td>evolving-hippo</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://evolving-hippo.dev-sc.dev.czi.team" target="_blank">https://evolving-hippo.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>
<!--ARGUS_STACK_DETAILS_END:do not remove this marker as it will break the argus metadata functionality-->

---

Fixes Issue #1040 

1. Add `mix-blend-mode` to canvas element in order to view under lying image better

Before: 
<img width="684" alt="Screenshot 2024-07-18 at 1 39 19 PM" src="https://github.com/user-attachments/assets/829a8581-03ec-4c6a-94f3-13e4fc81de66">


After:
<img width="696" alt="Screenshot 2024-07-18 at 1 38 52 PM" src="https://github.com/user-attachments/assets/d93193fc-eda0-45cc-a485-eaa3c9ef8083">
