### PR TITLE
test: Make test more robust

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-174a2b45
+        tag: sha-c765d258
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -1524,7 +1524,16 @@ for (const testDataset of testDatasets) {
 
             await page.getByTestId("download-graph-button").click();
 
-            expect(downloads.length).toBe(2);
+            /**
+             * (thuang): Sometimes in GHA there's only 1 download, so we need to retry
+             * until we get 2 downloads
+             */
+            await tryUntil(
+              () => {
+                expect(downloads.length).toBe(2);
+              },
+              { page }
+            );
 
             const afterMinimizeDownloads: Download[] = [];
 


### PR DESCRIPTION
I see that this test is flaky in GHA, so hopefully this fix helps!

My suspicion is that in GHA the downloads happen slower, so the assertion needs to run in a tryUntil 

```


   Retry #2 ───────────────────────────────────────────────────────────────────────────────────────

16825 Error: expect(received).toBe(expected) // Object.is equality

16826

16827 Expected: 2

16828 Received: 1

16829

16830 1525 | await page.getByTestId("download-graph-button").click();

16831 1526 |

16832 > 1527 | expect(downloads.length).toBe(2);

16833 | ^

16834 1528 |

16835 1529 | const afterMinimizeDownloads: Download[] = [];

16836 1530 |

16837

16838 at /home/runner/work/single-cell-explorer/single-cell-explorer/client/__tests__/e2e/e2e.test.ts:1527:38

16839Notice: 1 failed

16840 [chromium] › e2e/e2e.test.ts:1514:15 › dataset: super-cool-spatial.cxg › graph instance: layout-graph › Image Download › with side panel

16841 96 skipped

16842 130 passed (11.0m)

16843 1 failed

16844 [chromium] › e2e/e2e.test.ts:1514:15 › dataset: super-cool-spatial.cxg › graph instance: layout-graph › Image Download › with side panel
```