### PR TITLE
fix: Spatial mode dot size on highlight

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-c96bbaf8
+        tag: sha-7055e60c
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/src/util/glHelpers.ts
+++ b/client/src/util/glHelpers.ts
@@ -76,8 +76,8 @@ export const glPointSize = `
   float pointSize(float nPoints, float minViewportDimension, bool isSelected, bool isHighlight) {
       float density = nPoints / (minViewportDimension * minViewportDimension);
       float pointSize = (${scale.toFixed(4)}*density) + ${offset.toFixed(4)};
-      pointSize = clamp(pointSize, 
-      ${range[0].toFixed(4)}, 
+      pointSize = clamp(pointSize,
+      ${range[0].toFixed(4)},
       ${range[1].toFixed(4)});
 
     if (isHighlight) return 2. * pointSize;
@@ -91,7 +91,7 @@ export const densityFactor = 0.9;
 export const glPointSizeSpatial = `
 
   float pointSizeSpatial(float nPoints, float minViewportDimension, bool isSelected, bool isHighlight, float distance, float imageHeight, float scaleref, float spotDiameterFullres) {
-    
+
     float scaleFactor = (minViewportDimension / imageHeight) ;
 
 
@@ -101,11 +101,12 @@ export const glPointSizeSpatial = `
     float adjustedZoomFactor = clamp(zoomFactor, 0.1, .9); // Clamp the zoom factor to avoid extreme values and overlapping dots
 
     float baseSize = spotDiameterFullres * scaleref * scaleFactor * adjustedZoomFactor; // Base size proportional to viewport
-    
-    if (isSelected) {
-      return baseSize * 1.5; // Increase size if selected
-    } else if (isHighlight) {
-      return baseSize * 2.0; // Increase size if highlighted
+
+    // isHighlight has to be checked before isSelected to ensure that highlight works as intended
+    if (isHighlight) {
+      return baseSize * 2.0; // Increase size if selected
+    } else if (isSelected) {
+      return baseSize * 1.5; // Increase size if highlighted
     } else {
       return baseSize;
     }


### PR DESCRIPTION
context: https://czi-sci.slack.com/archives/C0247APK621/p1723740853441439?thread_ts=1723740810.796559&cid=C0247APK621

RDEV: https://well-bison.dev-sc.dev.czi.team/d/super-cool-spatial.cxg/

<!--ARGUS_STACK_DETAILS_START:https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>Name</th>
      <td>thuang-fix-spatial-highlight-dot-size</td>
    </tr>
    <tr>
      <th>Short Name</th>
      <td>well-bison</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://well-bison.dev-sc.dev.czi.team" target="_blank">https://well-bison.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>
<!--ARGUS_STACK_DETAILS_END:do not remove this marker as it will break the argus metadata functionality-->

---

1. Update logic to check `isHighlight` first like the original method in `glPointSize`

<img width="1341" alt="Screenshot 2024-08-15 at 10 35 45 AM" src="https://github.com/user-attachments/assets/0c47e679-36bb-406f-a45b-3bc832a4e077">


https://github.com/user-attachments/assets/77c97227-cab3-46e7-8fc8-8646eed511f1

