### PR TITLE
fix: skeleton loader

### DIFF
--- a/client/src/components/framework/layout.tsx
+++ b/client/src/components/framework/layout.tsx
@@ -20,7 +20,8 @@ interface Props {
 
 function Layout({ children, addTopPadding, renderGraph = undefined }: Props) {
   const [viewportRef, setViewportRef] = useState<HTMLDivElement | null>(null);
-  const [leftSidebar, rightSidebar] = Children.toArray(children);
+  const [leftSidebar, rightSidebar, ...restChildren] =
+    Children.toArray(children);
   let graphComponent = null;
   if (viewportRef && renderGraph) {
     graphComponent = renderGraph(viewportRef);
@@ -73,6 +74,7 @@ function Layout({ children, addTopPadding, renderGraph = undefined }: Props) {
         }}
       >
         {graphComponent}
+        {restChildren}
       </div>
       <div
         style={{

--- a/client/src/components/framework/layoutSkeleton.tsx
+++ b/client/src/components/framework/layoutSkeleton.tsx
@@ -8,12 +8,6 @@ import Layout from "./layout";
 import LeftSidebarSkeleton from "../leftSidebar/leftSidebarSkeleton";
 import RightSidebarSkeleton from "../rightSidebar/rightSidebarSkeleton";
 
-/* Padding between dataset selector and menubar */
-const PADDING_CONTROLS = 10;
-
-/* Width of menubar */
-const WIDTH_MENUBAR = 482;
-
 /**
  * Skeleton layout component displayed when in loading state.
  * @returns Markup displaying skeleton.
@@ -22,27 +16,19 @@ function LayoutSkeleton(): JSX.Element {
   return (
     <Layout addTopPadding>
       <LeftSidebarSkeleton />
+      <RightSidebarSkeleton />
       <Controls>
         <div
           style={{
             height: 30,
             position: "relative",
             top: 8,
-            width: `calc(100% - ${WIDTH_MENUBAR}px - ${PADDING_CONTROLS}px)`,
+            width: "100%",
           }}
           className={SKELETON}
-        />
-        <div
-          style={{
-            height: 30,
-            position: "relative",
-            top: 8,
-            width: WIDTH_MENUBAR,
-          }}
-          className={SKELETON}
+          data-testid="menubar-skeleton"
         />
       </Controls>
-      <RightSidebarSkeleton />
     </Layout>
   );
 }


### PR DESCRIPTION
The center Control Skeleton hasn't been working for a while, because the Layout component never called the render function!

This PR fixes it by adding a `...restChildren` in Layout and dump them along with the `graphComponent` in the center panel

<img width="1728" alt="Screenshot 2024-08-22 at 1 43 17 PM" src="https://github.com/user-attachments/assets/2417f362-7832-44f8-9f35-863f958b8e31">

https://github.com/user-attachments/assets/e6cc999f-307b-4c76-834f-f0edf6a27b56

