### PR TITLE
fix: og:title/image and fontFamily

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-06531c84
+        tag: sha-2d0fba9f
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-2d0fba9f
+        tag: sha-78bf2226
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/index.html
+++ b/client/index.html
@@ -66,6 +66,15 @@
     >
 
     <div id="root"></div>
+    <!-- Inject open graph image -->
+    <script>
+      document
+        .querySelector('meta[property="og:image"]')
+        .setAttribute(
+          "content",
+          `${window.location.pathname}static/images/cxg-explorer-og.jpg`
+        );
+    </script>
     <!-- for local testing add / to your file path /static/... -->
     <script
       async

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -67,6 +67,15 @@
     </noscript>
 
     <div id="root"></div>
+    <!-- Inject open graph image -->
+    <script>
+      document
+        .querySelector('meta[property="og:image"]')
+        .setAttribute(
+          "content",
+          `${window.location.pathname}static/images/cxg-explorer-og.jpg`
+        );
+    </script>
     <!-- for local testing add / to your file path /static/... -->
     <script
       async

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>CELL&times;GENE | Explorer</title>
+    <meta property="og:title" content="CELLxGENE | Explorer" />
+    <meta property="og:image" content="static/images/cxg-explorer-og.jpg" />
     <style>
       html,
       body,
@@ -35,6 +37,13 @@
         box-sizing: border-box;
       }
     </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:ital,wght@0,400;0,700;1,400&display=swap"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
     <script>
       var script = document.createElement('script')
       script.defer=true

--- a/client/src/components/theme.ts
+++ b/client/src/components/theme.ts
@@ -60,7 +60,12 @@ export const cornersNone = (props: CommonThemeProps) => getCorners(props)?.none;
 const tabularNums = "tabular-nums";
 
 const typography = {
-  fontFamily: "Roboto Condensed",
+  fontFamily: {
+    body: "Roboto Condensed",
+    caps: "Roboto Condensed",
+    header: "Roboto Condensed",
+    tabular: "Roboto Condensed",
+  },
 
   styles: {
     body: {
@@ -428,7 +433,6 @@ export const shadowL = (props: CommonThemeProps) => getShadows(props)?.l;
 export const shadowM = (props: CommonThemeProps) => getShadows(props)?.m;
 export const shadowS = (props: CommonThemeProps) => getShadows(props)?.s;
 
-// @ts-expect-error due to Typography mismatch in ThemeOptions
 const appTheme = makeThemeOptions(themeOptions);
 
 export const theme = createTheme(appTheme);

--- a/server/ecs/app.py
+++ b/server/ecs/app.py
@@ -50,7 +50,8 @@ class WSGIServer(Server):
             "form-action": ["'self'", HUBSPOT_FORMS_URL],
             "connect-src": ["'self'", PLAUSIBLE_URL, HUBSPOT_FORMS_URL, EXPLORER_DEV_URL] + extra_connect_src,
             "script-src": ["'self'", "'unsafe-eval'", PLAUSIBLE_URL, HUBSPOT_FORMS_URL, HUBSPOT_JS_URL] + script_hashes,
-            "style-src": ["'self'", "'unsafe-inline'"],
+            "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+            "font-src": ["'self'", "https://fonts.gstatic.com"],
             "img-src": ["'self'", "https://cellxgene.cziscience.com", EXPLORER_DEV_URL]
             + extra_connect_src
             + ["data:", HUBSPOT_FORMS_URL],


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>Name</th>
      <td>thuang-fix-og-title-font-family</td>
    </tr>
    <tr>
      <th>Short Name</th>
      <td>whole-finch</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://whole-finch.dev-sc.dev.czi.team" target="_blank">https://whole-finch.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>
<!--ARGUS_STACK_DETAILS_END:do not remove this marker as it will break the argus metadata functionality-->

---

Just realized that I had to add the meta tags in `index_template.html` as well in order to show up in the BE server served FE 🤦 One more reason to use Next.js to manage the FE build end to end!

Also updated the fontFamily declaration in the theme file to match the type shape, otherwise we get `undefined` for the SDS Chip style

Confirmed that the og:image works in FB Messenger this time!

<img width="384" alt="Screenshot 2024-08-27 at 8 04 12 AM" src="https://github.com/user-attachments/assets/e25ea975-985f-4add-8660-0b123b5f2802">

Font Roboto Condensed is successfully loaded now!

<img width="1727" alt="Screenshot 2024-08-27 at 8 09 48 AM" src="https://github.com/user-attachments/assets/90b3e45d-6933-49b9-83b1-f0a9bec4a54e">

NOTE:
The change still won't pass common open graph testing tool, because the og:image requires JS to update the content url, which the testing tool doesn't do