### PR TITLE
fix: SCE-20 Navbar use font Inter

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-31f6c13e
+        tag: sha-3b20504c
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-3adb7375
+        tag: sha-31f6c13e
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/index.html
+++ b/client/index.html
@@ -44,6 +44,10 @@
       rel="stylesheet"
       crossorigin="anonymous"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <script type="text/javascript">

--- a/client/index_template.html
+++ b/client/index_template.html
@@ -44,6 +44,7 @@
       rel="stylesheet"
       crossorigin="anonymous"
     />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
     <script>
       var script = document.createElement('script')
       script.defer=true

--- a/client/src/components/NavBar/style.ts
+++ b/client/src/components/NavBar/style.ts
@@ -20,6 +20,23 @@ export const Wrapper = styled.div`
   top: 0;
   width: 100%;
   z-index: 1;
+
+  /* Increase specificity for targeted elements specified in index.html and index_template.html */
+  p,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  span,
+  button,
+  input,
+  label,
+  text,
+  div {
+    font-family: "Inter", sans-serif;
+  }
 `;
 
 export const MainWrapper = styled.div`
@@ -110,4 +127,14 @@ export const BetaChip = styled(Tag)`
   color: white;
   margin-left: 4px;
   height: 16px !important;
+  margin-bottom: 0;
+  padding: 4px 6px;
+
+  .MuiChip-label {
+    font-family: "Inter", sans-serif;
+    font-weight: ${fontWeightSemibold};
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    font-size: 10px;
+  }
 `;


### PR DESCRIPTION
https://happy-duck.dev-sc.dev.czi.team/d/super-cool-spatial.cxg/

<!--ARGUS_STACK_DETAILS_START:https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>Name</th>
      <td>thuang-fix-navbar-font-to-inter</td>
    </tr>
    <tr>
      <th>Short Name</th>
      <td>happy-duck</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://happy-duck.dev-sc.dev.czi.team" target="_blank">https://happy-duck.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>
<!--ARGUS_STACK_DETAILS_END:do not remove this marker as it will break the argus metadata functionality-->

---

<img width="1256" alt="Screenshot 2024-09-20 at 10 19 35 AM" src="https://github.com/user-attachments/assets/5fc57287-da72-44d0-9673-e151307942e9">

UPDATE (9/23): Restyled BetaChip to match Data Portal too!

<img width="1481" alt="Screenshot 2024-09-23 at 1 24 10 PM" src="https://github.com/user-attachments/assets/a4f3f47d-6f2a-4e20-b87e-bea7ecb557f1">

