### PR TITLE
chore: bump chart versions

### DIFF
--- a/.infra/rdev/Chart.yaml
+++ b/.infra/rdev/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
 - name: stack
-  version: 1.3.0
+  version: 1.16.3
   repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/.infra/staging/Chart.yaml
+++ b/.infra/staging/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
 - name: stack
-  version: 1.3.0
+  version: 1.16.3
   repository: https://chanzuckerberg.github.io/argo-helm-charts


### PR DESCRIPTION
Updating the chart dependency since it's pretty old at this point. This will update it for staging and rdev, if staging looks good after this is merged I'll make another PR for prod