### PR TITLE
chore: Upgrade codecov

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,10 +23,12 @@ jobs:
         with:
           # Chromatic needs full Git history graph
           fetch-depth: 0
+
       - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
           python-version: 3.12
+
       - name: Python cache
         uses: actions/cache@v1
         with:
@@ -34,11 +36,13 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: "client/.nvmrc"
           cache: "npm"
           cache-dependency-path: "client/package-lock.json"
+
       - name: Install dependencies
         run: |
           make dev-env-server build-for-server-dev
@@ -48,7 +52,17 @@ jobs:
       - name: Smoke tests (without annotations feature)
         run: |
           cd client && CURRENT_SHARD=${{ matrix.shardIndex }} TOTAL_SHARDS=${{ matrix.shardTotal }} make smoke-test
-          ./node_modules/codecov/bin/codecov --yml=../.codecov.yml --root=../ --gcov-root=../ -C -F frontend,javascript,smokeTest
+
+      - name: Upload coverage reports to Codecov with GitHub Action
+        uses: codecov/codecov-action@v4.2.0
+        with:
+          root_dir: ../
+          flags: frontend,javascript,smokeTest
+          verbose: true
+          commit_parent: false
+          directory: client/
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Chromatic artifacts
         uses: actions/upload-artifact@v4

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-7d92494d
+        tag: sha-3adb7375
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -119,7 +119,7 @@
         "chromatic-playwright": "^0.4.1",
         "clean-css": "^5.1.2",
         "clean-webpack-plugin": "^4.0.0-alpha.0",
-        "codecov": "^3.7.1",
+        "codecov": "^3.8.3",
         "copy-webpack-plugin": "^9.0.1",
         "css-loader": "^5.2.4",
         "css-minimizer-webpack-plugin": "^4.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -163,7 +163,7 @@
     "chromatic-playwright": "^0.4.1",
     "clean-css": "^5.1.2",
     "clean-webpack-plugin": "^4.0.0-alpha.0",
-    "codecov": "^3.7.1",
+    "codecov": "^3.8.3",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^5.2.4",
     "css-minimizer-webpack-plugin": "^4.0.0",


### PR DESCRIPTION
Replace `npm` codecov package with their official Github Action plugin as recommended on:

https://github.com/codecov/codecov-action/tree/v4.2.0/