### PR TITLE
chore: default dot opacity 50% (SCE-27)

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-3b20504c
+        tag: sha-a694292f
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/src/reducers/controls.ts
+++ b/client/src/reducers/controls.ts
@@ -91,7 +91,7 @@ const Controls = (
       loading: false,
     },
     imageOpacity: isTest ? 0 : 100,
-    dotOpacity: 100,
+    dotOpacity: 50,
     expandedCategories: [],
   },
   action: AnyAction


### PR DESCRIPTION
<img width="1915" alt="Screenshot 2024-09-26 at 11 35 59 AM" src="https://github.com/user-attachments/assets/107e82ee-aa80-4425-9bd9-9911db435baf">
