### PR TITLE
chore: update for CytAssist

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-d4eaf649
+        tag: sha-f848aba8
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-ba19fbbe
+        tag: sha-d4eaf649
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/src/components/Graph/Graph.tsx
+++ b/client/src/components/Graph/Graph.tsx
@@ -24,7 +24,7 @@ import { Dataframe } from "util/dataframe";
 import { RootState } from "reducers";
 import { Field } from "common/types/schema";
 import { Query } from "annoMatrix/query";
-import { SLIDE_SIZE, THROTTLE_MS } from "util/constants";
+import { getSlideSize, THROTTLE_MS } from "util/constants";
 import { isSpatialMode, shouldShowOpenseadragon } from "common/selectors";
 import { fetchDeepZoomImageFailed } from "actions/config";
 import { track } from "analytics";
@@ -32,6 +32,7 @@ import { EVENTS } from "analytics/events";
 import { DatasetUnsMetadata } from "common/types/entities";
 import { getFeatureFlag } from "util/featureFlags/featureFlags";
 import { FEATURES } from "util/featureFlags/features";
+import { allSingleValues } from "util/singleValues";
 import { LassoFunctionWithAttributes } from "./setupLasso";
 import { CentroidLabels } from "./overlays/CentroidLabels/CentroidLabels";
 import { GraphOverlayLayer } from "./overlays/GraphOverlayLayer/GraphOverlayLayer";
@@ -1168,6 +1169,7 @@ class Graph extends React.Component<GraphProps, GraphState> {
       imageUnderlay,
       imageOpacity,
       unsMetadata,
+      annoMatrix: { schema },
     } = this.props;
 
     if (
@@ -1193,9 +1195,14 @@ class Graph extends React.Component<GraphProps, GraphState> {
       opacity: imageOpacity / 100,
     });
 
+    const assayOntologyTermId = allSingleValues({ schema }).get(
+      "assay_ontology_term_id"
+    );
+
     const { imageHeight } = unsMetadata;
 
-    const calculatedPixelsPerMeter = imageHeight / SLIDE_SIZE;
+    const calculatedPixelsPerMeter =
+      imageHeight / getSlideSize(assayOntologyTermId);
 
     this.openseadragon.scalebar({
       type: Openseadragon.ScalebarType.MICROSCOPY,

--- a/client/src/reducers/singleContinuousValue.ts
+++ b/client/src/reducers/singleContinuousValue.ts
@@ -19,7 +19,6 @@ const singleContinuousValue = (
 ): SingleContinuousValueState => {
   switch (action.type) {
     case "add single continuous value":
-
       state.singleContinuousValues.set(action.field, action.value);
       return state;
     default:

--- a/client/src/util/constants.ts
+++ b/client/src/util/constants.ts
@@ -13,6 +13,14 @@ export const SCALE_MAX_HIRES = 12.0;
  *  https://kb.10xgenomics.com/hc/en-us/articles/360035487572-What-is-the-spatial-resolution-and-configuration-of-the-capture-area-of-the-Visium-v1-Gene-Expression-Slide
  */
 export const SLIDE_SIZE = 0.008;
+export const SLIDE_SIZE_CYT_ASSIST = 0.011;
+
+export function getSlideSize(assayOntologyTermId: string): number {
+  if (assayOntologyTermId === "EFO:0022860") {
+    return SLIDE_SIZE_CYT_ASSIST;
+  }
+  return SLIDE_SIZE;
+}
 
 export const LAYOUT_CHOICE_TEST_ID = "layout-choice";
 

--- a/client/src/util/singleValues.ts
+++ b/client/src/util/singleValues.ts
@@ -1,0 +1,16 @@
+import { Schema } from "common/types/schema";
+import { selectableCategoryNames } from "./stateManager/controlsHelpers";
+
+export function allSingleValues({ schema }: { schema: Schema }) {
+  const singleValues = new Map();
+  const allCategoryNames = () => selectableCategoryNames(schema).sort();
+
+  allCategoryNames().forEach((catName) => {
+    const colSchema = schema.annotations.obsByName[catName];
+    const isUserAnno = colSchema?.writable;
+    if (!isUserAnno && colSchema.categories?.length === 1) {
+      singleValues.set(catName, colSchema.categories[0]);
+    }
+  });
+  return singleValues;
+}

--- a/server/dataset/cxg_dataset.py
+++ b/server/dataset/cxg_dataset.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-import pickle
+import pickle  # TODO: remove this after 5.3.0 migration
 import threading
 
 import numpy as np
@@ -388,7 +388,9 @@ class CxgDataset(Dataset):
         for key in uns.meta:
             if key == metadata_key:
                 try:
-                    return pickle.loads(uns.meta[key])
+                    if type(uns.meta[key]) == bytes:  # TODO: remove this after 5.3.0 migration
+                        return pickle.loads(uns.meta[key])  # for backwards compatibility
+                    return json.loads(uns.meta[key])
                 except Exception as e:
                     print(f"Error deserializing uns data for key {key}: {e}")
                     return None


### PR DESCRIPTION
Related: https://github.com/chanzuckerberg/single-cell-explorer/issues/1146

This adds support for CytAssist Visium assays - slide size for scale bar calculation is now based on `assay_ontology_term_id` 

<img width="1506" alt="Screenshot 2025-02-11 at 6 06 55 PM" src="https://github.com/user-attachments/assets/b09c1a38-5b4f-4ecb-98e6-6b5317707bef" />
