### PR TITLE
chore: upgrade docker builder

### DIFF
--- a/.github/workflows/docker-build-staging-prod.yaml
+++ b/.github/workflows/docker-build-staging-prod.yaml
@@ -11,3 +11,4 @@ jobs:
       envs: staging,prod
       path_filters: '!.infra/**'
       branches: release-please--branches--main
+      force_update_manifests: true

--- a/.github/workflows/workflow-argus-docker-build.yaml
+++ b/.github/workflows/workflow-argus-docker-build.yaml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: ''
+      force_update_manifests:
+        description: 'Whether to always update ArgoCD manifests after building the Docker images'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   get_commit_sha:
@@ -33,24 +38,47 @@ jobs:
         id: get_sha
         run: |
           echo "COMMIT_SHA=$(git rev-parse --verify HEAD)" >> $GITHUB_OUTPUT
-  argus_builder:
-    needs: get_commit_sha
-    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v2.13.2
+  merge_images:
+    name: Merge images inputs
+    runs-on: ARM64
+    outputs:
+      images: ${{ steps.merge_images.outputs.result }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install lodash
+      - name: Merge images inputs with defaults
+        id: merge_images
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const _ = require('lodash');
+            const defaultImages = {
+              "explorer": {
+                "context": ".",
+                "dockerfile": "hosted/Dockerfile",
+                "platform": "linux/amd64",
+                "build_args": [
+                  "COMMIT_SHA=${{ needs.get_commit_sha.outputs.commit_sha }}"
+                ]
+              }
+            };
+            const images = JSON.parse(`${{ inputs.images }}`);
+            const mergedImages = _.merge(defaultImages, images);
+            console.log('Default images:', JSON.stringify(defaultImages, null, 2));
+            console.log('Input images:', JSON.stringify(images, null, 2));
+            console.log('Merged images:', JSON.stringify(mergedImages, null, 2));
+            return JSON.stringify(mergedImages);
+  argus_docker_build:
+    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v4.2.0
     secrets: inherit
+    needs: merge_images
     with:
-      branches: ${{ inputs.branches }}
+      branches_include: ${{ inputs.branches }}
       branches_ignore: ${{ inputs.branches_ignore }}
       path_filters: ${{ inputs.path_filters }}
       envs: ${{ inputs.envs }}
-      images: |
-        [
-          {
-            "name": "explorer",
-            "context": ".",
-            "dockerfile": "hosted/Dockerfile",
-            "platform": "linux/amd64",
-            "build_args": [
-              "COMMIT_SHA=${{ needs.get_commit_sha.outputs.commit_sha }}"
-            ]
-          }
-        ]
+      images: ${{ needs.merge_images.outputs.images }}
+      force_update_manifests: ${{ inputs.force_update_manifests }}

--- a/.github/workflows/workflow-argus-docker-build.yaml
+++ b/.github/workflows/workflow-argus-docker-build.yaml
@@ -7,8 +7,13 @@ on:
         description: 'Env names, comma delimited'
         required: true
         type: string
+      images:
+        description: 'Image configurations (JSON object of images to build)'
+        required: false
+        type: string
+        default: '{}'
       path_filters:
-        description: 'Glob patterns to match against changed files in the repository, comma delimited'
+        description: 'String with path filters to match before building, comma delimited'
         required: true
         type: string
       branches:

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-f848aba8
+        tag: sha-afc0b98
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/hosted/Dockerfile
+++ b/hosted/Dockerfile
@@ -40,4 +40,3 @@ LABEL commit=${COMMIT_SHA}
 ENV COMMIT_SHA=${COMMIT_SHA}
 
 CMD ["/start.sh"]
-# bump

--- a/hosted/Dockerfile
+++ b/hosted/Dockerfile
@@ -40,3 +40,4 @@ LABEL commit=${COMMIT_SHA}
 ENV COMMIT_SHA=${COMMIT_SHA}
 
 CMD ["/start.sh"]
+# bump


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>Name</th>
      <td>jakeyheath-patch-1</td>
    </tr>
    <tr>
      <th>Short Name</th>
      <td>patient-terrapin</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://patient-terrapin.dev-sc.dev.czi.team" target="_blank">https://patient-terrapin.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>
<!--ARGUS_STACK_DETAILS_END:do not remove this marker as it will break the argus metadata functionality-->

---

https://czi.atlassian.net/browse/CCIE-4050

This upgrades to using v4.2.0 of the argus builder which has detection of whether a PR has the stack label built-in, ie rdev values.yaml will only be updated now when the stack label is on a PR

Additionally, and more importantly, this new version uses the newer self-hosted runners
