### PR TITLE
chore: bump helm charts to make use of NLB

### DIFF
--- a/.infra/prod/Chart.yaml
+++ b/.infra/prod/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
   - name: stack
-    version: 1.16.3
+    version: 2.6.1
     repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/.infra/rdev/Chart.yaml
+++ b/.infra/rdev/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
   - name: stack
-    version: 2.2.3
+    version: 2.6.1
     repository: https://chanzuckerberg.github.io/argo-helm-charts

--- a/.infra/staging/Chart.yaml
+++ b/.infra/staging/Chart.yaml
@@ -5,5 +5,5 @@ version: 1.0.0
 
 dependencies:
   - name: stack
-    version: 2.2.3
+    version: 2.6.1
     repository: https://chanzuckerberg.github.io/argo-helm-charts


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-4211

## Summary

We have switched to using NLBs instead of ALBs, however in order to make use of these new network configurations, the application needs to run on the latest version of the helm chart.