### PR TITLE
chore: bump argus docker builder

### DIFF
--- a/.github/workflows/workflow-argus-docker-build.yaml
+++ b/.github/workflows/workflow-argus-docker-build.yaml
@@ -77,7 +77,7 @@ jobs:
             console.log('Merged images:', JSON.stringify(mergedImages, null, 2));
             return JSON.stringify(mergedImages);
   argus_docker_build:
-    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v4.2.0
+    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v5
     secrets: inherit
     needs: merge_images
     with:


### PR DESCRIPTION
Use the latest major tag so it picks up all minor and patch releases