### PR TITLE
feat: fix w routing to exclude static assets from glob

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -27,7 +27,7 @@ from server.app.api.v3 import register_api_v3
 from server.app.logging import configure_logging
 from server.app.request_id import generate_request_id, get_request_id
 from server.common.config.app_config import AppConfig
-from server.common.constants import CELLGUIDE_CXG_KEY_NAME
+from server.common.constants import CELLGUIDE_CXG_KEY_NAME, CUSTOM_CXG_KEY_NAME
 from server.common.errors import (
     DatasetAccessError,
     DatasetNotFoundError,
@@ -199,9 +199,11 @@ class Server:
             url_dataroot = dataroot_dict["base_url"]
             if url_dataroot == "w":
                 self.app.add_url_rule(
-                    f"/{url_dataroot}/<path:dataset>/",
+                    f"/{url_dataroot}/{CUSTOM_CXG_KEY_NAME}/<path:dataset>.cxg/",
                     f"dataset_index_{url_dataroot}/",
-                    lambda dataset, url_dataroot=url_dataroot: dataset_index(url_dataroot, dataset),
+                    lambda dataset, url_dataroot=url_dataroot: dataset_index(
+                        url_dataroot, f"{CUSTOM_CXG_KEY_NAME}/{dataset}.cxg"
+                    ),
                     methods=["GET"],
                 )
             else:

--- a/server/common/constants.py
+++ b/server/common/constants.py
@@ -35,5 +35,6 @@ REACTIVE_LIMIT = 1_000_000
 MAX_LAYOUTS = 30
 
 CELLGUIDE_CXG_KEY_NAME = "cellguide-cxgs"
+CUSTOM_CXG_KEY_NAME = "custom-cxgs"
 
 CELLGUIDE_BASE_URL = "https://cellguide.cellxgene.cziscience.com"

--- a/server/common/rest.py
+++ b/server/common/rest.py
@@ -15,6 +15,7 @@ from server.app.api.util import get_dataset_artifact_s3_uri
 from server.common.config.client_config import get_client_config
 from server.common.constants import (
     CELLGUIDE_CXG_KEY_NAME,
+    CUSTOM_CXG_KEY_NAME,
     Axis,
     DiffExpMode,
     JSON_NaN_to_num_warning_msg,
@@ -167,11 +168,12 @@ def dataset_metadata_get(app_config, url_dataroot, dataset_id):
 
 def s3_uri_get(app_config, url_dataroot_id, dataset_id):
     # This is a hack to work around the fact that the flask routes
-    # need to hardcode `{CELLGUIDE_CXG_KEY_NAME}/` in the blueprint, but the
-    # s3_uri must include that prefix.
-    # TODO: make this less hacky.
+    # need to hardcode the key name prefix in the blueprint.
     if not dataset_id.endswith(".cxg"):
-        dataset_id = f"{CELLGUIDE_CXG_KEY_NAME}/{dataset_id}.cxg"
+        if url_dataroot_id == "w":
+            dataset_id = f"{CUSTOM_CXG_KEY_NAME}/{dataset_id}.cxg"
+        else:
+            dataset_id = f"{CELLGUIDE_CXG_KEY_NAME}/{dataset_id}.cxg"
 
     try:
         dataset_artifact_s3_uri = get_dataset_artifact_s3_uri(url_dataroot_id, dataset_id)


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:app=single-cell-explorer&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>App Name</th>
      <td>single-cell-explorer</td>
    </tr>
    <tr>
      <th>Stack Name</th>
      <td>star-barnacle</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://star-barnacle.dev-sc.dev.czi.team" target="_blank">https://star-barnacle.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>
<!--ARGUS_STACK_DETAILS_END:app=single-cell-explorer&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->

---

