### PR TITLE
fix: GeneSets bug

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-3ef2abc
+        tag: sha-da493ac
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-38afd6b
+        tag: sha-3ef2abc
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/__tests__/e2e/cell-guide.test.ts
+++ b/client/__tests__/e2e/cell-guide.test.ts
@@ -132,6 +132,9 @@ describe("CellGuideCXG", () => {
     // Refresh the page
     await page.reload();
 
+    // Wait for page to fully load after reload
+    await page.waitForLoadState("networkidle");
+
     await expandMarkerGeneSetsHeader(page);
 
     // Check if the geneset is added back

--- a/client/__tests__/e2e/cell-guide.test.ts
+++ b/client/__tests__/e2e/cell-guide.test.ts
@@ -135,8 +135,8 @@ describe("CellGuideCXG", () => {
     await expandMarkerGeneSetsHeader(page);
 
     // Check if the geneset is added back
-    const genesetPresence = await page.locator(
-      `div[data-testid="geneset"]:has-text("enteric smooth muscle cell")`
+    const genesetPresence = await page.getByTestId(
+      "enteric smooth muscle cell - marker genes:geneset-name"
     );
     await expect(genesetPresence).toBeVisible();
   });

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -1834,7 +1834,7 @@ test("categories and values from dataset appear and properly truncate if applica
         .getByTestId("categorical-row")
         .all();
 
-      expect(Object.keys(categoryRows).length).toBe(1001);
+      expect(Object.keys(categoryRows).length).toBe(1101);
     },
     { page }
   );

--- a/client/src/components/RightSideBar/components/GeneExpression/GeneExpression.tsx
+++ b/client/src/components/RightSideBar/components/GeneExpression/GeneExpression.tsx
@@ -99,16 +99,21 @@ class GeneExpression extends React.Component<{}, State> {
         const displayName = name.replace(MARKER_GENE_SUFFIX_IDENTIFIER, "");
         const updatedGenes = new Map();
 
-        // find ensembl IDs for each gene in the geneset
         for (const [geneName, geneData] of geneset.genes) {
+          const geneIdIndex = geneIds.indexOf(geneName);
+          const geneNameIndex = geneNames.indexOf(geneName);
+
           const geneId = geneIds
-            ? geneIds[geneNames.indexOf(geneName)] || ""
+            ? geneIds[geneNameIndex] || geneIds[geneIdIndex] || ""
             : "";
+
+          const actualGeneName =
+            geneIdIndex === -1 ? geneName : geneNames[geneIdIndex];
 
           if (geneId) {
             updatedGenes.set(geneId, geneData);
             genesetIds.push(geneId);
-            genesetNames.push(geneName);
+            genesetNames.push(actualGeneName);
           } else {
             console.warn(`No ID found for gene: ${geneName}`);
           }

--- a/client/src/components/RightSideBar/components/GeneExpression/components/Gene/Gene.tsx
+++ b/client/src/components/RightSideBar/components/GeneExpression/components/Gene/Gene.tsx
@@ -187,7 +187,12 @@ class Gene extends React.Component<Props, State> {
 
   handleDeleteGeneFromSet = (): void => {
     const { dispatch, gene, geneset } = this.props;
-    dispatch(actions.genesetDeleteGenes(geneset, [gene.name]));
+
+    const isDEGeneSet = geneset ? geneset.startsWith("Pop") : false;
+
+    const nameToDelete = isDEGeneSet ? gene.id : gene.name;
+
+    dispatch(actions.genesetDeleteGenes(geneset, [nameToDelete]));
   };
 
   handleOpenMultiomeViz = (): void => {

--- a/server/default_config.py
+++ b/server/default_config.py
@@ -93,7 +93,7 @@ default_dataset:
     about_legal_privacy: null
 
   presentation:
-    max_categories: 1000
+    max_categories: 30000
     custom_colors: true
 
   embeddings:

--- a/server/tests/unit/common/config/__init__.py
+++ b/server/tests/unit/common/config/__init__.py
@@ -93,7 +93,7 @@ class ConfigTests(BaseTest):
         inline_scripts=None,
         about_legal_tos="null",
         about_legal_privacy="null",
-        max_categories=1000,
+        max_categories=30000,
         custom_colors="true",
         enable_users_annotations="true",
         annotation_type="local_file_csv",

--- a/server/tests/unit/common/config/test_dataset_config.py
+++ b/server/tests/unit/common/config/test_dataset_config.py
@@ -34,7 +34,7 @@ class TestDatasetConfig(ConfigTests):
 
     def test_init_datatset_config_sets_vars_from_default_config(self):
         app_config = AppConfig()
-        self.assertEqual(app_config.default_dataset__presentation__max_categories, 1000)
+        self.assertEqual(app_config.default_dataset__presentation__max_categories, 30000)
         self.assertEqual(app_config.default_dataset__diffexp__lfc_cutoff, 0.01)
 
     def test_app_sets_script_vars(self):


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:app=single-cell-explorer&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>App Name</th>
      <td>single-cell-explorer</td>
    </tr>
    <tr>
      <th>Stack Name</th>
      <td>mature-elf</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://mature-elf.dev-sc.dev.czi.team" target="_blank">https://mature-elf.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>

---
<!--ARGUS_STACK_DETAILS_END:app=single-cell-explorer&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
Related to: https://github.com/chanzuckerberg/single-cell-explorer/issues/1231 and https://github.com/chanzuckerberg/single-cell-explorer/issues/1233

RDEV - https://mature-elf.dev-sc.dev.czi.team/d/super-cool-spatial.cxg/

Users reported issues where:
- Gene list under GeneSets were not appearing when using Differential Expression feature
- Genes are missing from gene search

Changes:
- Updated Gene Expression logic to handle DE genesets while maintaining same functionality for user genesets
- Updated max categories to avoid omitting genes from the list - previously capped at 1000