### PR TITLE
fix: Update Explorer to use feature_name

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-66802b7
+        tag: sha-d4062ba
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-da493ac
+        tag: sha-66802b7
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/client/__tests__/e2e/e2e.test.ts
+++ b/client/__tests__/e2e/e2e.test.ts
@@ -1834,7 +1834,7 @@ test.skip("categories and values from dataset appear and properly truncate if ap
         .getByTestId("categorical-row")
         .all();
 
-      expect(Object.keys(categoryRows).length).toBe(1101);
+      expect(Object.keys(categoryRows).length).toBe(1001);
     },
     { page }
   );

--- a/client/src/actions/geneset.ts
+++ b/client/src/actions/geneset.ts
@@ -55,9 +55,18 @@ export const genesetAddGenes =
   (genesetName: any, genes: any) => async (dispatch: any, getState: any) => {
     const state = getState();
     const { obsCrossfilter: prevObsCrossfilter, annoMatrix } = state;
+    const { schema } = annoMatrix;
+    // Fallback
+    const varIndex = schema.annotations.var.index;
     const varFeatureName = VAR_FEATURE_NAME_COLUMN;
-    const df: Dataframe = await annoMatrix.fetch("var", varFeatureName);
-    const geneNames = df.col(varFeatureName).asArray();
+    // Check if VAR_FEATURE_NAME_COLUMN exists, otherwise use the index
+    const varColumns = annoMatrix.getMatrixColumns("var");
+    const columnName = varColumns.includes(varFeatureName)
+      ? varFeatureName
+      : varIndex;
+
+    const df: Dataframe = await annoMatrix.fetch("var", columnName);
+    const geneNames = df.col(columnName).asArray();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
     genes = genes.reduce((acc: any, gene: any) => {
       if (geneNames.indexOf(gene.geneSymbol) === -1) {

--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -5,6 +5,7 @@ import {
 } from "util/transientLocalStorage";
 import { KEYS } from "util/localStorage";
 import { fetchJson } from "util/fetch";
+import { VAR_FEATURE_NAME_COLUMN } from "common/constants";
 import type { Config } from "../globals";
 import * as globals from "../globals";
 import { AnnoMatrixLoader, AnnoMatrixObsCrossfilter } from "../annoMatrix";
@@ -391,7 +392,7 @@ const requestDifferentialExpression =
       */
       const { annoMatrix } = getState();
 
-      const varIndexName = annoMatrix.schema.annotations.var.index;
+      const varFeatureName = VAR_FEATURE_NAME_COLUMN;
 
       // // Legal values are null, Array or TypedArray.  Null is initial state.
       if (!set1) set1 = new Int32Array();
@@ -434,7 +435,8 @@ const requestDifferentialExpression =
 
       const response = await res.json();
 
-      const varIndex = await annoMatrix.fetch(Field.var, varIndexName);
+      const varLabel = await annoMatrix.fetch(Field.var, varFeatureName);
+
       const diffexpLists = { negative: [], positive: [] };
       for (const polarity of Object.keys(
         diffexpLists
@@ -443,7 +445,7 @@ const requestDifferentialExpression =
           // TODO: swap out with type defined at genesets reducer when made
           (v: [LabelIndex, number, number, number]) => [
             // @ts-expect-error (seve): fix downstream lint errors as a result of detailed app store typing
-            varIndex.at(v[0], varIndexName),
+            varLabel.at(v[0], varFeatureName),
             ...v.slice(1),
           ]
         );
@@ -576,7 +578,6 @@ const updateLocation = (url: string) => (dispatch: AppDispatch) => {
   dispatch({ type: "location update" });
   window.history.pushState(null, "", url);
 };
-
 
 export const revertToAction = (targetCount: number) => ({
   type: "@@undoable/revert-to-action",

--- a/client/src/actions/index.ts
+++ b/client/src/actions/index.ts
@@ -392,8 +392,6 @@ const requestDifferentialExpression =
       */
       const { annoMatrix } = getState();
 
-      const varFeatureName = VAR_FEATURE_NAME_COLUMN;
-
       // // Legal values are null, Array or TypedArray.  Null is initial state.
       if (!set1) set1 = new Int32Array();
       if (!set2) set2 = new Int32Array();
@@ -435,7 +433,17 @@ const requestDifferentialExpression =
 
       const response = await res.json();
 
-      const varLabel = await annoMatrix.fetch(Field.var, varFeatureName);
+      // Fallback
+      const { schema } = annoMatrix;
+      const varIndex = schema.annotations.var.index;
+      const varFeatureName = VAR_FEATURE_NAME_COLUMN;
+      // Check if VAR_FEATURE_NAME_COLUMN exists, otherwise use the index
+      const varColumns = annoMatrix.getMatrixColumns(Field.var);
+      const columnName = varColumns.includes(varFeatureName)
+        ? varFeatureName
+        : varIndex;
+
+      const varLabel = await annoMatrix.fetch(Field.var, columnName);
 
       const diffexpLists = { negative: [], positive: [] };
       for (const polarity of Object.keys(
@@ -445,7 +453,7 @@ const requestDifferentialExpression =
           // TODO: swap out with type defined at genesets reducer when made
           (v: [LabelIndex, number, number, number]) => [
             // @ts-expect-error (seve): fix downstream lint errors as a result of detailed app store typing
-            varLabel.at(v[0], varFeatureName),
+            varLabel.at(v[0], columnName),
             ...v.slice(1),
           ]
         );

--- a/client/src/annoMatrix/normalize.ts
+++ b/client/src/annoMatrix/normalize.ts
@@ -72,7 +72,14 @@ export function normalizeResponse(
       writable;
     // If "feature_id" column exists, should not normalize
     // (gene info cards require ensembl ID of any gene, and normalizing overwrites some of those IDs)
-    if (!isIndex && colLabel !== "feature_id" && isEnumType) {
+    // If "feature_name" column exists, should not normalize
+    // (gene names are needed for differential expression and should preserve individual gene identities)
+    if (
+      !isIndex &&
+      colLabel !== "feature_id" &&
+      colLabel !== "feature_name" &&
+      isEnumType
+    ) {
       response = normalizeCategorical(response, colLabel, colSchema);
     }
   }

--- a/client/src/common/components/BrushableHistogram/BrushableHistogram.tsx
+++ b/client/src/common/components/BrushableHistogram/BrushableHistogram.tsx
@@ -3,6 +3,7 @@ import { connect, shallowEqual } from "react-redux";
 import * as d3 from "d3";
 import Async from "react-async";
 import memoize from "memoize-one";
+import { VAR_FEATURE_NAME_COLUMN } from "common/constants";
 import actions from "actions";
 import { makeContinuousDimensionName } from "util/nameCreators";
 import { Dataframe } from "util/dataframe";
@@ -487,6 +488,8 @@ class HistogramBrush extends React.PureComponent<BrushableHistogramProps> {
     const varIndex = schema?.annotations?.var?.index;
     if (!varIndex) return null;
 
+    const varLabel = VAR_FEATURE_NAME_COLUMN;
+
     if (isGeneSetSummary && setGenes) {
       return [
         Field.X,
@@ -494,7 +497,7 @@ class HistogramBrush extends React.PureComponent<BrushableHistogramProps> {
           summarize: {
             method: "mean",
             field: "var",
-            column: varIndex,
+            column: varLabel,
             values: [...setGenes.keys()],
           },
         },
@@ -507,7 +510,7 @@ class HistogramBrush extends React.PureComponent<BrushableHistogramProps> {
       {
         where: {
           field: "var",
-          column: varIndex,
+          column: varLabel,
           value: field,
         },
       },

--- a/client/src/common/components/BrushableHistogram/BrushableHistogram.tsx
+++ b/client/src/common/components/BrushableHistogram/BrushableHistogram.tsx
@@ -480,15 +480,17 @@ class HistogramBrush extends React.PureComponent<BrushableHistogramProps> {
   }
 
   createQuery(): [Field, Query] | null {
-    const { isObs, isGeneSetSummary, field, setGenes, annoMatrix } = this.props;
-    const { schema } = annoMatrix;
+    const { isObs, isGeneSetSummary, field, setGenes } = this.props;
     if (isObs) {
       return [Field.obs, field];
     }
-    const varIndex = schema?.annotations?.var?.index;
-    if (!varIndex) return null;
 
-    const varLabel = VAR_FEATURE_NAME_COLUMN;
+    // Check if VAR_FEATURE_NAME_COLUMN exists, otherwise use the index
+    const { annoMatrix } = this.props;
+    const varColumns = annoMatrix.getMatrixColumns(Field.var);
+    const columnName = varColumns.includes(VAR_FEATURE_NAME_COLUMN)
+      ? VAR_FEATURE_NAME_COLUMN
+      : annoMatrix.schema.annotations.var.index;
 
     if (isGeneSetSummary && setGenes) {
       return [
@@ -497,7 +499,7 @@ class HistogramBrush extends React.PureComponent<BrushableHistogramProps> {
           summarize: {
             method: "mean",
             field: "var",
-            column: varLabel,
+            column: columnName,
             values: [...setGenes.keys()],
           },
         },
@@ -510,7 +512,7 @@ class HistogramBrush extends React.PureComponent<BrushableHistogramProps> {
       {
         where: {
           field: "var",
-          column: varLabel,
+          column: columnName,
           value: field,
         },
       },

--- a/client/src/common/constants.ts
+++ b/client/src/common/constants.ts
@@ -1,1 +1,4 @@
 export const EMPTY_ARRAY = [];
+
+// Column name for gene names in the annomatrix
+export const VAR_FEATURE_NAME_COLUMN = "feature_name";

--- a/client/src/components/RightSideBar/components/GeneExpression/GeneExpression.tsx
+++ b/client/src/components/RightSideBar/components/GeneExpression/GeneExpression.tsx
@@ -5,7 +5,7 @@ import { IconNames } from "@blueprintjs/icons";
 
 import { track } from "analytics";
 import { EVENTS } from "analytics/events";
-import { Dataframe } from "util/dataframe";
+import { Dataframe, DataframeValue } from "util/dataframe";
 
 import { GeneSet } from "./components/GeneSet/GeneSet";
 import { QuickGene } from "./components/QuickGene/QuickGene";
@@ -47,21 +47,24 @@ class GeneExpression extends React.Component<{}, State> {
     if (!schema) return;
 
     const varIndex = schema.annotations.var.index;
-    const varLabel = "feature_name";
 
-    const dfIds: Dataframe = await annoMatrix.fetch("var", varIndex);
+    let dfIds;
+    const df: Dataframe = await annoMatrix?.fetch("var", varIndex);
 
-    const varColumns = annoMatrix.getMatrixColumns("var");
-
-    // This is a fallback in case the varLabel is not available.
-    const labelToUse = varColumns.includes(varLabel) ? varLabel : varIndex;
-
-    const dfNames: Dataframe = await annoMatrix.fetch("var", labelToUse);
+    if (!df) return;
 
     this.setState({
-      geneIds: dfIds.col(varIndex).asArray(),
-      geneNames: dfNames.col(labelToUse).asArray(),
+      geneNames: df.col(varIndex).asArray() as DataframeValue[],
     });
+
+    const geneIdCol = "feature_id";
+    // if feature id column is available in var
+    if (annoMatrix.getMatrixColumns("var").includes(geneIdCol)) {
+      dfIds = await annoMatrix.fetch("var", geneIdCol);
+      this.setState({
+        geneIds: dfIds.col(geneIdCol).asArray() as DataframeValue[],
+      });
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types --- FIXME: disabled temporarily on migrate to TS.
@@ -97,33 +100,21 @@ class GeneExpression extends React.Component<{}, State> {
         const genesetIds = [];
         const genesetNames = [];
         const displayName = name.replace(MARKER_GENE_SUFFIX_IDENTIFIER, "");
-        const updatedGenes = new Map();
 
-        for (const [geneName, geneData] of geneset.genes) {
-          const geneIdIndex = geneIds.indexOf(geneName);
-          const geneNameIndex = geneNames.indexOf(geneName);
-
+        // find ensembl IDs for each gene in the geneset
+        for (const gene of geneset.genes) {
           const geneId = geneIds
-            ? geneIds[geneNameIndex] || geneIds[geneIdIndex] || ""
+            ? geneIds[geneNames.indexOf(gene[0])] || ""
             : "";
-
-          const actualGeneName =
-            geneIdIndex === -1 ? geneName : geneNames[geneIdIndex];
-
-          if (geneId) {
-            updatedGenes.set(geneId, geneData);
-            genesetIds.push(geneId);
-            genesetNames.push(actualGeneName);
-          } else {
-            console.warn(`No ID found for gene: ${geneName}`);
-          }
+          genesetIds.push(geneId);
+          genesetNames.push(gene[0]);
         }
 
         sets.push(
           <GeneSet
             key={name}
             // @ts-expect-error ts-migrate(2322) FIXME: Type '{ key: any; setGenes: any; setName: any; gen... Remove this comment to see the full error message
-            setGenes={updatedGenes}
+            setGenes={geneset.genes}
             setName={name}
             displayName={displayName}
             genesetDescription={geneset.genesetDescription}

--- a/client/src/components/RightSideBar/components/GeneExpression/components/Gene/Gene.tsx
+++ b/client/src/components/RightSideBar/components/GeneExpression/components/Gene/Gene.tsx
@@ -95,7 +95,7 @@ class Gene extends React.Component<Props, State> {
     track(EVENTS.EXPLORER_DELETE_FROM_GENESET_BUTTON_CLICKED);
 
     if (quickGene) {
-      removeGene?.(gene.name)();
+      removeGene?.(gene)();
     } else {
       this.handleDeleteGeneFromSet();
     }
@@ -135,13 +135,11 @@ class Gene extends React.Component<Props, State> {
 
   onColorChangeClick = async () => {
     const { dispatch, gene, isColorAccessor } = this.props;
-    const { id } = gene;
-
     if (!isColorAccessor) {
       // only track color change when turned on
       track(EVENTS.EXPLORER_COLORBY_GENE);
     }
-    dispatch(actions.requestSingleGeneExpressionCountsForColoringPOST(id));
+    dispatch(actions.requestSingleGeneExpressionCountsForColoringPOST(gene));
 
     /**
      * (thuang): Must be dispatched AFTER the actions above, as the `colorMode`
@@ -168,31 +166,24 @@ class Gene extends React.Component<Props, State> {
   handleSetGeneAsScatterplotX = (): void => {
     track(EVENTS.EXPLORER_PLOT_X_BUTTON_CLICKED);
     const { dispatch, gene } = this.props;
-    const { id } = gene;
     dispatch({
       type: "set scatterplot x",
-      data: id,
+      data: gene,
     });
   };
 
   handleSetGeneAsScatterplotY = (): void => {
     track(EVENTS.EXPLORER_PLOT_Y_BUTTON_CLICKED);
     const { dispatch, gene } = this.props;
-    const { id } = gene;
     dispatch({
       type: "set scatterplot y",
-      data: id,
+      data: gene,
     });
   };
 
   handleDeleteGeneFromSet = (): void => {
     const { dispatch, gene, geneset } = this.props;
-
-    const isDEGeneSet = geneset ? geneset.startsWith("Pop") : false;
-
-    const nameToDelete = isDEGeneSet ? gene.id : gene.name;
-
-    dispatch(actions.genesetDeleteGenes(geneset, [nameToDelete]));
+    dispatch(actions.genesetDeleteGenes(geneset, [gene]));
   };
 
   handleOpenMultiomeViz = (): void => {
@@ -200,22 +191,20 @@ class Gene extends React.Component<Props, State> {
 
     dispatch({
       type: "open multiome viz panel",
-      selectedGene: gene.name,
+      selectedGene: gene,
     });
   };
 
   handleDisplayGeneInfo = async (): Promise<void> => {
-    const { dispatch, gene } = this.props;
-    const { name, id } = gene;
-
+    const { dispatch, gene, geneId } = this.props;
     track(EVENTS.EXPLORER_VIEW_GENE_INFO, {
-      gene: name,
+      gene,
     });
 
-    dispatch({ type: "request gene info start", gene: name });
+    dispatch({ type: "request gene info start", gene });
     dispatch({ type: "toggle active info panel", activeTab: ActiveTab.Gene });
 
-    const info = await actions.fetchGeneInfo(name, id, dispatch);
+    const info = await actions.fetchGeneInfo(gene, geneId, dispatch);
 
     if (!info) {
       return;
@@ -223,7 +212,7 @@ class Gene extends React.Component<Props, State> {
 
     dispatch({
       type: "open gene info",
-      gene: name,
+      gene,
       info,
     });
   };
@@ -254,7 +243,7 @@ class Gene extends React.Component<Props, State> {
           <div
             role="menuitem"
             tabIndex={0}
-            data-testid={`${gene.name}:gene-expand`}
+            data-testid={`${gene}:gene-expand`}
             style={{
               cursor: "pointer",
               display: "flex",
@@ -272,15 +261,15 @@ class Gene extends React.Component<Props, State> {
                     width: geneSymbolWidth,
                     display: "inline-block",
                   }}
-                  data-testid={`${gene.name}:gene-label`}
+                  data-testid={`${gene}:gene-label`}
                 >
-                  {gene.name}
+                  {gene}
                 </span>
               </Truncate>
             </div>
             <InfoButtonWrapper>
               <InfoButton
-                data-testid={`get-info-${gene.name}`}
+                data-testid={`get-info-${gene}`}
                 onClick={this.handleDisplayGeneInfo}
                 disabled={!isGeneExpressionComplete}
                 sdsType="tertiary"
@@ -294,7 +283,7 @@ class Gene extends React.Component<Props, State> {
               <div style={{ width: MINI_HISTOGRAM_WIDTH }}>
                 <BrushableHistogram
                   isUserDefined
-                  field={gene.id}
+                  field={gene}
                   mini
                   width={MINI_HISTOGRAM_WIDTH}
                   onGeneExpressionComplete={onGeneExpressionComplete}
@@ -306,7 +295,7 @@ class Gene extends React.Component<Props, State> {
             <Button
               minimal
               small
-              data-testid={`maximize-${gene.id}`}
+              data-testid={`maximize-${gene}`}
               onClick={this.handleGeneExpandClick}
               active={geneIsExpanded}
               intent="none"
@@ -326,7 +315,7 @@ class Gene extends React.Component<Props, State> {
               <Button
                 minimal
                 small
-                data-testid={`more-actions:${gene.name}`}
+                data-testid={`more-actions:${gene}`}
                 intent="none"
                 icon={<Icon icon="more" size={10} />}
                 style={{ marginRight: 2 }}
@@ -335,7 +324,7 @@ class Gene extends React.Component<Props, State> {
             <Button
               minimal
               small
-              data-testid={`colorby-${gene.id}`}
+              data-testid={`colorby-${gene}`}
               onClick={this.onColorChangeClick}
               active={isColorAccessor}
               intent={isColorAccessor ? "primary" : "none"}
@@ -346,7 +335,7 @@ class Gene extends React.Component<Props, State> {
         {geneIsExpanded && (
           <BrushableHistogram
             isUserDefined
-            field={gene.id}
+            field={gene}
             onGeneExpressionComplete={() => {}}
           />
         )}

--- a/client/src/components/RightSideBar/components/GeneExpression/components/Gene/types.ts
+++ b/client/src/components/RightSideBar/components/GeneExpression/components/Gene/types.ts
@@ -18,7 +18,7 @@ export interface DispatchProps {
 }
 
 export interface OwnProps {
-  gene: { name: string; id: string };
+  gene: string;
   quickGene?: boolean;
   removeGene?: (gene: string) => () => void;
   geneId: DataframeValue;
@@ -38,11 +38,11 @@ export const mapStateToProps = (
 
   return {
     isColorAccessor:
-      state.colors.colorAccessor === gene.id &&
+      state.colors.colorAccessor === gene &&
       state.colors.colorMode !== "color by categorical metadata",
-    isScatterplotXXaccessor: state.controls.scatterplotXXaccessor === gene.id,
-    isScatterplotYYaccessor: state.controls.scatterplotYYaccessor === gene.id,
-    isGeneInfo: state.controls.geneInfo.gene === gene.id,
+    isScatterplotXXaccessor: state.controls.scatterplotXXaccessor === gene,
+    isScatterplotYYaccessor: state.controls.scatterplotYYaccessor === gene,
+    isGeneInfo: state.controls.geneInfo.gene === gene,
     hasChromatinData: state.controls.hasChromatinData,
   };
 };

--- a/client/src/components/RightSideBar/components/GeneExpression/components/GeneSet/GeneSet.tsx
+++ b/client/src/components/RightSideBar/components/GeneExpression/components/GeneSet/GeneSet.tsx
@@ -57,18 +57,16 @@ export class GeneSet extends React.Component<{}, State> {
   renderGenes() {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'setName' does not exist on type 'Readonl... Remove this comment to see the full error message
     const { setName, setGenes, geneIds, geneNames } = this.props;
-    const setGenesIds = [...setGenes.keys()];
+    const setGenesNames = [...setGenes.keys()];
     return (
       <div data-testid="gene-set-genes">
-        {setGenesIds.map((geneId) => {
-          const { geneDescription } = setGenes.get(geneId);
-          const geneName = geneNames[geneIds.indexOf(geneId)];
-          const geneObject = { id: geneId, name: geneName };
-
+        {setGenesNames.map((gene) => {
+          const { geneDescription } = setGenes.get(gene);
+          const geneId = geneIds[geneNames.indexOf(gene)];
           return (
             <Gene
-              key={geneName}
-              gene={geneObject}
+              key={gene}
+              gene={gene}
               geneDescription={geneDescription}
               geneset={setName}
               geneId={geneId}

--- a/client/src/components/RightSideBar/components/GeneExpression/components/QuickGene/QuickGene.tsx
+++ b/client/src/components/RightSideBar/components/GeneExpression/components/QuickGene/QuickGene.tsx
@@ -148,16 +148,15 @@ export function QuickGene() {
       threshold: -10000,
     });
 
-  const QuickGenes = useMemo((): JSX.Element => {
-    const removeGene = (gene: string) => () => {
-      dispatch({ type: "clear user defined gene", gene });
-    };
-
-    return userDefinedGenes.map((gene: string) => {
+  const QuickGenes = useMemo((): JSX.Element => userDefinedGenes.map((gene: string) => {
       let geneId = geneIds[geneNames.indexOf(gene)];
       if (!geneId) {
         geneId = "";
       }
+
+      const removeGene = (geneToRemove: string) => () => {
+        dispatch({ type: "clear user defined gene", gene: geneToRemove });
+      };
 
       return (
         <Gene
@@ -170,8 +169,7 @@ export function QuickGene() {
           onGeneExpressionComplete={noop}
         />
       );
-    });
-  }, [userDefinedGenes, geneNames, geneIds, dispatch]);
+    }), [userDefinedGenes, geneNames, geneIds, dispatch]);
 
   return (
     <div style={{ width: "100%", marginBottom: "16px" }}>

--- a/client/src/components/RightSideBar/components/GeneExpression/components/QuickGene/QuickGene.tsx
+++ b/client/src/components/RightSideBar/components/GeneExpression/components/QuickGene/QuickGene.tsx
@@ -1,12 +1,6 @@
 import { H4, Icon, MenuItem } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useMemo,
-  useCallback,
-} from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import fuzzysort from "fuzzysort";
 import { ItemRenderer, Suggest } from "@blueprintjs/select";
 import { useSelector, useDispatch } from "react-redux";
@@ -14,11 +8,17 @@ import { useSelector, useDispatch } from "react-redux";
 import { noop } from "lodash";
 
 import { postUserErrorToast } from "components/framework/toasters";
+import { VAR_FEATURE_NAME_COLUMN } from "common/constants";
 import actions from "actions";
 import { Dataframe, DataframeValue } from "util/dataframe";
 import { track } from "analytics";
 import { EVENTS } from "analytics/events";
 import Gene from "../Gene/Gene";
+import {
+  FuzzySortResult,
+  Item,
+  RenderItemProps,
+} from "../InfoPanel/components/InfoPanelContainer/components/InfoSearch/types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
 const usePrevious = (value: any) => {
@@ -57,46 +57,37 @@ export function QuickGene() {
     (async function fetch() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on commit
       if (annoMatrix !== (prevProps as any)?.annoMatrix) {
-        const { schema } = annoMatrix;
-        const varIndex = schema.annotations.var.index;
-        const varLabel = "feature_name";
+        const varFeatureName = VAR_FEATURE_NAME_COLUMN;
 
         setStatus("pending");
         try {
-          const dfIds: Dataframe = await annoMatrix.fetch("var", varIndex);
-          const varColumns = annoMatrix.getMatrixColumns("var");
-
-          // This is a fallback in case the varLabel is not available.
-          const labelToUse = varColumns.includes(varLabel)
-            ? varLabel
-            : varIndex;
-          const dfNames: Dataframe = await annoMatrix.fetch("var", labelToUse);
-
-          const geneIdArray = dfIds.col(varIndex).asArray() as string[];
-          const geneNameArray = dfNames.col(labelToUse).asArray() as string[];
-
+          const df: Dataframe = await annoMatrix.fetch("var", varFeatureName);
+          let dfIds: Dataframe;
+          const geneIdCol = "feature_id";
           const isFilteredCol = "feature_is_filtered";
           const isFiltered =
             annoMatrix.getMatrixColumns("var").includes(isFilteredCol) &&
             (await annoMatrix.fetch("var", isFilteredCol));
 
+          // if feature id column is available in var
+          if (annoMatrix.getMatrixColumns("var").includes(geneIdCol)) {
+            dfIds = await annoMatrix.fetch("var", geneIdCol);
+            setGeneIds(dfIds.col("feature_id").asArray() as DataframeValue[]);
+          }
+
+          setStatus("success");
+
           if (isFiltered) {
             const isFilteredArray = isFiltered.col(isFilteredCol).asArray();
-
-            const filteredGeneNames = geneNameArray.filter(
-              (_, index) => !isFilteredArray[index] && _
+            setGeneNames(
+              df
+                .col(varFeatureName)
+                .asArray()
+                .filter((_, index) => !isFilteredArray[index] && _) as string[]
             );
-            const filteredGeneIds = geneIdArray.filter(
-              (_, index) => !isFilteredArray[index] && _
-            );
-
-            setGeneNames(filteredGeneNames);
-            setGeneIds(filteredGeneIds);
           } else {
-            setGeneNames(geneNameArray);
-            setGeneIds(geneIdArray);
+            setGeneNames(df.col(varFeatureName).asArray() as string[]);
           }
-          setStatus("success");
         } catch (error) {
           setStatus("error");
           throw error;
@@ -110,55 +101,37 @@ export function QuickGene() {
   }, [dispatch, geneNames]);
 
   const handleExpand = () => setIsExpanded(!isExpanded);
-  const renderGene: ItemRenderer<{ name: string; id: string }> = (
-    item,
-    { modifiers }
+
+  const renderGene: ItemRenderer<string | FuzzySortResult> = (
+    item: string | FuzzySortResult,
+    { modifiers }: RenderItemProps
   ) => {
-    if (!modifiers.matchesPredicate) return null;
+    if (!modifiers.matchesPredicate) {
+      return null;
+    }
+    const geneName = typeof item === "string" ? item : item.target;
 
     return (
       <MenuItem
         active={modifiers.active}
         disabled={modifiers.disabled}
-        data-testid={`suggest-menu-item-${item.name}`}
-        key={item.id}
-        onClick={() => handleClick(item)}
-        text={item.name}
+        data-testid={`suggest-menu-item-${geneName}`}
+        key={geneName}
+        onClick={() => {
+          handleClick(item);
+        }}
+        text={geneName}
       />
     );
   };
 
-  const itemListPredicate = useCallback((query: string, items: Item[]) => {
-    if (!query.trim()) return items;
-
-    const matches = filterGenes(
-      query,
-      items.map((i) => i.name)
-    );
-    const matchedNames = new Set(matches.map((m) => m.target));
-    return items.filter((item) => matchedNames.has(item.name));
-  }, []);
-
-  const geneItems = useMemo(() => {
-    const EMPTY_GENE_ITEM = { name: "No genes", id: "" };
-    if (!geneNames?.length || !geneIds?.length) {
-      return [EMPTY_GENE_ITEM];
-    }
-
-    return geneNames.map((name, i) => ({
-      name,
-      id: String(geneIds[i] ?? ""),
-    }));
-  }, [geneNames, geneIds]);
-
-  type Item = { name: string; id: string };
-
-  const handleClick = (item: Item) => {
-    const { id: gene, name: geneName } = item;
-
+  const handleClick = (g: Item) => {
+    if (!g) return;
+    const item = typeof g === "string" ? g : g.target;
+    const gene = item;
     if (userDefinedGenes.indexOf(gene) !== -1) {
       postUserErrorToast("That gene already exists");
-    } else if (geneNames.indexOf(geneName) === -1) {
+    } else if (geneNames.indexOf(gene) === undefined) {
       postUserErrorToast("That doesn't appear to be a valid gene name.");
     } else {
       track(EVENTS.EXPLORER_ADD_GENE);
@@ -176,18 +149,21 @@ export function QuickGene() {
     });
 
   const QuickGenes = useMemo((): JSX.Element => {
-    const removeGene = (geneId: string) => () => {
-      dispatch({ type: "clear user defined gene", gene: geneId });
+    const removeGene = (gene: string) => () => {
+      dispatch({ type: "clear user defined gene", gene });
     };
-    return userDefinedGenes.map((geneId: string) => {
-      const geneIndex = geneIds.indexOf(geneId);
-      const geneName = geneNames[geneIndex] ?? geneId;
+
+    return userDefinedGenes.map((gene: string) => {
+      let geneId = geneIds[geneNames.indexOf(gene)];
+      if (!geneId) {
+        geneId = "";
+      }
 
       return (
         <Gene
-          key={`quick=${geneId}`}
-          gene={{ name: geneName, id: geneId }}
-          removeGene={() => removeGene(geneId)}
+          key={`quick=${gene}`}
+          gene={gene}
+          removeGene={removeGene}
           quickGene
           geneId={geneId}
           isGeneExpressionComplete
@@ -219,21 +195,12 @@ export function QuickGene() {
       {isExpanded && (
         <>
           <div style={{ marginBottom: "8px" }} data-testid="gene-search">
-            <Suggest<Item>
+            <Suggest
               resetOnSelect
               closeOnSelect
               resetOnClose
-              disabled={userDefinedGenesLoading}
-              noResults={
-                <MenuItem
-                  disabled
-                  text={
-                    userDefinedGenesLoading
-                      ? "Loading genes..."
-                      : "No matching genes."
-                  }
-                />
-              }
+              itemDisabled={userDefinedGenesLoading ? () => true : () => false}
+              noResults={<MenuItem disabled text="No matching genes." />}
               onItemSelect={(g) => {
                 handleClick(g);
               }}
@@ -242,10 +209,12 @@ export function QuickGene() {
                 placeholder: "Quick Gene Search",
                 leftIcon: IconNames.SEARCH,
               }}
-              inputValueRenderer={(item) => item.name}
-              itemListPredicate={itemListPredicate}
-              itemRenderer={renderGene}
-              items={geneItems}
+              inputValueRenderer={() => ""}
+              itemListPredicate={(query: string, items: string[]) =>
+                filterGenes(query, items) as unknown as string[]
+              }
+              itemRenderer={renderGene as ItemRenderer<string>}
+              items={geneNames || ["No genes"]}
               popoverProps={{ minimal: true }}
               fill
             />

--- a/client/src/components/scatterplot/scatterplot.tsx
+++ b/client/src/components/scatterplot/scatterplot.tsx
@@ -7,6 +7,7 @@ import { mat3 } from "gl-matrix";
 import memoize from "memoize-one";
 import Async from "react-async";
 
+import { VAR_FEATURE_NAME_COLUMN } from "../../common/constants";
 import * as globals from "../../globals";
 // @ts-expect-error ts-migrate(2307) FIXME: Cannot find module './scatterplot.css' or its corr... Remove this comment to see the full error message
 import styles from "./scatterplot.css";
@@ -103,6 +104,22 @@ class Scatterplot extends React.PureComponent<{}, State> {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   static watchAsync(props: any, prevProps: any) {
     return !shallowEqual(props.watchProps, prevProps.watchProps);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
+  static createXQuery(geneName: any) {
+    const varFeatureName = VAR_FEATURE_NAME_COLUMN;
+    if (!varFeatureName) return null;
+    return [
+      "X",
+      {
+        where: {
+          field: "var",
+          column: varFeatureName,
+          value: geneName,
+        },
+      },
+    ];
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any --- FIXME: disabled temporarily on migrate to TS.
@@ -315,25 +332,6 @@ class Scatterplot extends React.PureComponent<{}, State> {
   };
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
-  createXQuery(geneName: any) {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
-    const { annoMatrix } = this.props;
-    const { schema } = annoMatrix;
-    const varIndex = schema?.annotations?.var?.index;
-    if (!varIndex) return null;
-    return [
-      "X",
-      {
-        where: {
-          field: "var",
-          column: varIndex,
-          value: geneName,
-        },
-      },
-    ];
-  }
-
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- - FIXME: disabled temporarily on migrate to TS.
   createColorByQuery(colors: any) {
     // @ts-expect-error ts-migrate(2339) FIXME: Property 'annoMatrix' does not exist on type 'Read... Remove this comment to see the full error message
     const { annoMatrix, genesets } = this.props;
@@ -380,11 +378,11 @@ class Scatterplot extends React.PureComponent<{}, State> {
       [
         annoMatrix.fetch(
           // @ts-expect-error ts-migrate(2488) FIXME: Type '(string | { where: { field: string; column: ... Remove this comment to see the full error message
-          ...this.createXQuery(scatterplotXXaccessor),
+          ...Scatterplot.createXQuery(scatterplotXXaccessor),
           globals.numBinsObsX
         ),
         annoMatrix.fetch(
-          ...this.createXQuery(scatterplotYYaccessor),
+          ...Scatterplot.createXQuery(scatterplotYYaccessor),
           globals.numBinsObsX
         ),
         query

--- a/client/src/util/stateManager/colorHelpers.ts
+++ b/client/src/util/stateManager/colorHelpers.ts
@@ -4,6 +4,7 @@
 import * as d3 from "d3";
 import { interpolateRainbow, interpolateCool } from "d3-scale-chromatic";
 import memoize from "memoize-one";
+import { VAR_FEATURE_NAME_COLUMN } from "../../common/constants";
 import * as globals from "../../globals";
 import parseRGB from "../parseRGB";
 import { range } from "../range";
@@ -45,23 +46,23 @@ export function createColorQuery(
       return [Field.obs, colorByAccessor];
     }
     case "color by expression": {
-      const varIndex = schema?.annotations?.var?.index;
-      if (!varIndex) return null;
+      const varFeatureName = VAR_FEATURE_NAME_COLUMN;
+      if (!varFeatureName) return null;
       return [
         Field.X,
         {
           where: {
             field: "var",
-            column: varIndex,
+            column: varFeatureName,
             value: colorByAccessor,
           },
         },
       ];
     }
     case "color by geneset mean expression": {
-      const varIndex = schema?.annotations?.var?.index;
+      const varFeatureName = VAR_FEATURE_NAME_COLUMN;
 
-      if (!varIndex) return null;
+      if (!varFeatureName) return null;
       if (!genesets) return null;
 
       const geneset = genesets.get(colorByAccessor);
@@ -73,7 +74,7 @@ export function createColorQuery(
           summarize: {
             method: "mean",
             field: "var",
-            column: varIndex,
+            column: varFeatureName,
             values: setGenes,
           },
         },

--- a/client/src/util/stateManager/colorHelpers.ts
+++ b/client/src/util/stateManager/colorHelpers.ts
@@ -39,6 +39,11 @@ export function createColorQuery(
   genesets: Genesets
 ): [Field, Query] | null {
   if (!colorMode || !colorByAccessor || !schema || !genesets) return null;
+  // Check if VAR_FEATURE_NAME_COLUMN exists, otherwise use the index
+  const varColumns = Object.keys(schema.annotations.varByName);
+  const varFeatureName = varColumns.includes(VAR_FEATURE_NAME_COLUMN)
+    ? VAR_FEATURE_NAME_COLUMN
+    : schema.annotations.var.index;
 
   switch (colorMode) {
     case "color by categorical metadata":
@@ -46,7 +51,6 @@ export function createColorQuery(
       return [Field.obs, colorByAccessor];
     }
     case "color by expression": {
-      const varFeatureName = VAR_FEATURE_NAME_COLUMN;
       if (!varFeatureName) return null;
       return [
         Field.X,
@@ -60,8 +64,6 @@ export function createColorQuery(
       ];
     }
     case "color by geneset mean expression": {
-      const varFeatureName = VAR_FEATURE_NAME_COLUMN;
-
       if (!varFeatureName) return null;
       if (!genesets) return null;
 

--- a/server/default_config.py
+++ b/server/default_config.py
@@ -93,7 +93,7 @@ default_dataset:
     about_legal_privacy: null
 
   presentation:
-    max_categories: 30000
+    max_categories: 1000
     custom_colors: true
 
   embeddings:

--- a/server/tests/unit/common/config/__init__.py
+++ b/server/tests/unit/common/config/__init__.py
@@ -93,7 +93,7 @@ class ConfigTests(BaseTest):
         inline_scripts=None,
         about_legal_tos="null",
         about_legal_privacy="null",
-        max_categories=30000,
+        max_categories=1000,
         custom_colors="true",
         enable_users_annotations="true",
         annotation_type="local_file_csv",

--- a/server/tests/unit/common/config/test_dataset_config.py
+++ b/server/tests/unit/common/config/test_dataset_config.py
@@ -34,7 +34,7 @@ class TestDatasetConfig(ConfigTests):
 
     def test_init_datatset_config_sets_vars_from_default_config(self):
         app_config = AppConfig()
-        self.assertEqual(app_config.default_dataset__presentation__max_categories, 30000)
+        self.assertEqual(app_config.default_dataset__presentation__max_categories, 1000)
         self.assertEqual(app_config.default_dataset__diffexp__lfc_cutoff, 0.01)
 
     def test_app_sets_script_vars(self):


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:app=single-cell-explorer&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>App Name</th>
      <td>single-cell-explorer</td>
    </tr>
    <tr>
      <th>Stack Name</th>
      <td>natural-hermit</td>
    </tr>
    <tr>
      <th>Base URL</th>
      <td><a href="https://natural-hermit.dev-sc.dev.czi.team" target="_blank">https://natural-hermit.dev-sc.dev.czi.team</a></td>
    </tr>
  </table>
</details>

---
<!--ARGUS_STACK_DETAILS_END:app=single-cell-explorer&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->

Related to: https://github.com/chanzuckerberg/single-cell-explorer/issues/1231 and https://github.com/chanzuckerberg/single-cell-explorer/issues/1233

- Updated key functionality to use `feature_name` var column to support post 6.0 schema migrations CxGs
- Reverted the previous implementation
- Added fallback to support test dataset and scenarios where `feature_name` column is not present