### PR TITLE
fix: Grab organism_ontology_term_id from config

### DIFF
--- a/client/src/common/hooks/useChromatinViewerSelectedGene.tsx
+++ b/client/src/common/hooks/useChromatinViewerSelectedGene.tsx
@@ -5,6 +5,8 @@ import React, {
   useEffect,
   ReactNode,
 } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "../../reducers";
 
 interface ChromatinViewerContextType {
   selectedGene: string;
@@ -26,13 +28,50 @@ export function ChromatinViewerProvider({
   children,
   initialSelectedGene,
 }: ChromatinViewerProviderProps) {
-  const DEFAULT_GENE = "MYC";
   const DEFAULT_GENOME_VERSION = "hg38";
+  const DEFAULT_GENE = "MYC";
+
+  // Get organism ontology term ID from config to determine genome version
+  const config = useSelector((state: RootState) => state.config);
+  const organismOntologyTermId =
+    config?.corpora_props?.organism_ontology_term_id;
+
+  // Map organism ontology term ID to genome version
+  const getGenomeVersionFromOrganism = (ontologyTermId?: string): string => {
+    switch (ontologyTermId) {
+      case "NCBITaxon:9606": // Human
+        return "hg38";
+      case "NCBITaxon:10090": // Mouse
+        return "mm39";
+      default:
+        return DEFAULT_GENOME_VERSION;
+    }
+  };
+
+  // Map organism ontology term ID to default gene
+  const getDefaultGeneFromOrganism = (ontologyTermId?: string): string => {
+    switch (ontologyTermId) {
+      case "NCBITaxon:9606":
+        return "MYC";
+      case "NCBITaxon:10090":
+        return "Vip";
+      default:
+        return DEFAULT_GENE;
+    }
+  };
+
+  const detectedGenomeVersion = getGenomeVersionFromOrganism(
+    organismOntologyTermId
+  );
+  const detectedDefaultGene = getDefaultGeneFromOrganism(
+    organismOntologyTermId
+  );
+
   const [selectedGene, setSelectedGene] = useState<string>(
-    initialSelectedGene || DEFAULT_GENE
+    initialSelectedGene || detectedDefaultGene
   );
   const [genomeVersion, setGenomeVersionState] = useState<string>(
-    DEFAULT_GENOME_VERSION
+    detectedGenomeVersion
   );
 
   // Update selected gene when initialSelectedGene changes (from Redux)
@@ -41,6 +80,22 @@ export function ChromatinViewerProvider({
       setSelectedGene(initialSelectedGene);
     }
   }, [initialSelectedGene]);
+
+  // Update genome version when organism ontology term ID changes
+  useEffect(() => {
+    const newGenomeVersion = getGenomeVersionFromOrganism(
+      organismOntologyTermId
+    );
+    setGenomeVersionState(newGenomeVersion);
+  }, [organismOntologyTermId]);
+
+  // Update default gene when organism ontology term ID changes (only if no initial gene provided)
+  useEffect(() => {
+    if (!initialSelectedGene) {
+      const newDefaultGene = getDefaultGeneFromOrganism(organismOntologyTermId);
+      setSelectedGene(newDefaultGene);
+    }
+  }, [organismOntologyTermId, initialSelectedGene]);
 
   const setGenomeVersion = (version: string) => {
     setGenomeVersionState(version);

--- a/server/dataset/cxg_dataset.py
+++ b/server/dataset/cxg_dataset.py
@@ -403,7 +403,10 @@ class CxgDataset(Dataset):
         bin_size = ATAC_BIN_SIZE
         range_buffer = ATAC_RANGE_BUFFER
 
-        target_chromosome, gene_start, gene_end, sorted_genes = self.get_atac_gene_info(gene_name, genome_version)
+        gene_info = self.get_atac_gene_info(gene_name, genome_version)
+        if gene_info is None:
+            raise DatasetAccessError(f"Gene '{gene_name}' not found in genome version '{genome_version}'")
+        target_chromosome, gene_start, gene_end, sorted_genes = gene_info
 
         # Determine genomic region of interest
         bin_start = (gene_start - range_buffer) // bin_size


### PR DESCRIPTION
Updated the ChromatinViewerProvider to dynamically detect genome version and default gene (MYC for human, Vip for mouse) from the dataset's organism ontology term ID.