### PR TITLE
test: POC: Zarr-backed dataset adaptor alongside TileDB/CXG

### DIFF
--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-14fc6b5
+        tag: sha-dc4b0fa
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/.infra/rdev/values.yaml
+++ b/.infra/rdev/values.yaml
@@ -2,7 +2,7 @@ stack:
   services:
     explorer:
       image:
-        tag: sha-dc4b0fa
+        tag: sha-7a74a5a
       replicaCount: 1
       env:
         # env vars common to all deployment stages

--- a/scripts/cxg_to_zarr.py
+++ b/scripts/cxg_to_zarr.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""Convert a TileDB .cxg dataset to an AnnData .zarr store, for the Zarr-adaptor POC.
+
+Reads via the existing CxgDataset adaptor so the zarr fixture matches the .cxg one exactly.
+Read-only POC scope: X, obs, var, embeddings, colors. No user annotations / genesets.
+
+Usage:
+    python scripts/cxg_to_zarr.py <input.cxg> <output.zarr>
+"""
+import sys
+
+import anndata
+import numpy as np
+import pandas as pd
+
+# anndata's zarr v2 writer can't serialize Arrow-backed strings; keep object strings as object.
+pd.set_option("future.infer_string", False)
+
+from server.common.config.app_config import AppConfig
+from server.common.utils.data_locator import DataLocator
+from server.dataset.cxg_dataset import CxgDataset
+
+
+def _minimal_config():
+    config = AppConfig()
+    config.update_server_config(app__flask_secret_key="x", multi_dataset__dataroot="/test/")
+    config.complete_config()
+    return config
+
+
+def _coerce(values, col_schema):
+    """Reconstruct the logical column. CxgDataset.query_*_array returns raw codes for
+    categorical columns, so rebuild categoricals from the cxg schema. anndata's zarr writer
+    can't serialize Arrow-backed strings (pandas 2.x default), so non-categorical strings -> object."""
+    if col_schema and col_schema.get("type") == "categorical" and "categories" in col_schema:
+        categories = col_schema["categories"]
+        arr = np.asarray(values)
+        if arr.dtype.kind in ("i", "u"):
+            return pd.Categorical.from_codes(arr, categories=categories)
+        return pd.Categorical(
+            [v.decode() if isinstance(v, bytes) else str(v) for v in arr], categories=categories
+        )
+    s = pd.Series(values)
+    if pd.api.types.is_categorical_dtype(s):
+        return s.values
+    if pd.api.types.is_numeric_dtype(s) or pd.api.types.is_bool_dtype(s):
+        return np.asarray(s)
+    return np.array([v.decode() if isinstance(v, bytes) else str(v) for v in s], dtype=object)
+
+
+def _frame(keys, query_fn, index_name, schema_cols):
+    """Build a DataFrame from adaptor column queries, using index_name's column as the index."""
+    by_name = {c["name"]: c for c in schema_cols}
+    df = pd.DataFrame({k: _coerce(query_fn(k), by_name.get(k)) for k in keys})
+    df.index = pd.Index(np.asarray(df[index_name]).astype(object), name=index_name)
+    return df
+
+
+def convert(cxg_path: str, zarr_path: str) -> None:
+    ds = CxgDataset(DataLocator(cxg_path), _minimal_config())
+    schema = ds.get_schema()
+    obs_index = schema["annotations"]["obs"].get("index", ds.get_obs_keys()[0])
+    var_index = schema["annotations"]["var"].get("index", ds.get_var_keys()[0])
+
+    obs = _frame(ds.get_obs_keys(), ds.query_obs_array, obs_index, schema["annotations"]["obs"]["columns"])
+    var = _frame(ds.get_var_keys(), ds.query_var_array, var_index, schema["annotations"]["var"]["columns"])
+
+    # Full dense X (POC fixtures are small). None masks -> whole matrix.
+    X = np.asarray(ds.get_X_array(None, None))
+    obsm = {f"X_{name}": np.asarray(ds.get_embedding_array(name)) for name in ds.get_embedding_names()}
+
+    uns = {}
+    colors = ds.get_colors()
+    if colors:
+        uns["cxg_category_colors"] = colors
+
+    adata = anndata.AnnData(X=X, obs=obs, var=var, obsm=obsm, uns=uns)
+    adata.write_zarr(zarr_path)
+    ds.cleanup()
+    print(f"wrote {zarr_path}: {adata.shape[0]} obs x {adata.shape[1]} var, embeddings={list(obsm)}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+    convert(sys.argv[1], sys.argv[2])

--- a/scripts/cxg_to_zarr.py
+++ b/scripts/cxg_to_zarr.py
@@ -37,9 +37,7 @@ def _coerce(values, col_schema):
         arr = np.asarray(values)
         if arr.dtype.kind in ("i", "u"):
             return pd.Categorical.from_codes(arr, categories=categories)
-        return pd.Categorical(
-            [v.decode() if isinstance(v, bytes) else str(v) for v in arr], categories=categories
-        )
+        return pd.Categorical([v.decode() if isinstance(v, bytes) else str(v) for v in arr], categories=categories)
     s = pd.Series(values)
     if pd.api.types.is_categorical_dtype(s):
         return s.values

--- a/server/common/rest.py
+++ b/server/common/rest.py
@@ -307,7 +307,7 @@ def dataset_metadata_get(app_config, url_dataroot, dataset_id):
 def s3_uri_get(app_config, url_dataroot_id, dataset_id):
     # This is a hack to work around the fact that the flask routes
     # need to hardcode the key name prefix in the blueprint.
-    if not dataset_id.endswith(".cxg"):
+    if not dataset_id.endswith(".cxg") and not dataset_id.endswith(".zarr"):  # ponytail: .zarr POC
         if url_dataroot_id == "w":
             dataset_id = f"{CUSTOM_CXG_KEY_NAME}/{dataset_id}.cxg"
         else:

--- a/server/dataset/matrix_loader.py
+++ b/server/dataset/matrix_loader.py
@@ -14,9 +14,15 @@ class DataLoader(object):
         if not self.location.exists():
             raise DatasetAccessError("Dataset does not exist.", HTTPStatus.NOT_FOUND)
 
-        from server.dataset.cxg_dataset import CxgDataset
+        # ponytail: suffix dispatch; a registry only if a 3rd backend appears.
+        if str(self.location.uri_or_path).rstrip("/").endswith(".zarr"):
+            from server.dataset.zarr_dataset import ZarrDataset
 
-        self.matrix_type = CxgDataset
+            self.matrix_type = ZarrDataset
+        else:
+            from server.dataset.cxg_dataset import CxgDataset
+
+            self.matrix_type = CxgDataset
 
     def __resolve_dataset_config(self):
         dataset_config = self.app_config.default_dataset

--- a/server/dataset/zarr_dataset.py
+++ b/server/dataset/zarr_dataset.py
@@ -117,7 +117,7 @@ class ZarrDataset(Dataset):
         return ename if ename in self.adata.obsm else f"X_{ename}"
 
     def get_embedding_names(self):
-        names = [k[2:] if k.startswith("X_") else k for k in self.adata.obsm.keys()]
+        names = [k[2:] if k.startswith("X_") else k for k in self.adata.obsm]
         if not names:
             raise DatasetAccessError("zarr matrix missing embeddings")
         return names
@@ -169,9 +169,14 @@ class ZarrDataset(Dataset):
         meanA, varA, nA = mean_var_n(self.get_X_array(mask(rowsA)), dist)
         meanB, varB, nB = mean_var_n(self.get_X_array(mask(rowsB)), dist)
         return diffexp_ttest_from_mean_var(
-            meanA=meanA.astype(dtype), varA=varA.astype(dtype), nA=nA,
-            meanB=meanB.astype(dtype), varB=varB.astype(dtype), nB=nB,
-            top_n=top_n, diffexp_lfc_cutoff=lfc_cutoff,
+            meanA=meanA.astype(dtype),
+            varA=varA.astype(dtype),
+            nA=nA,
+            meanB=meanB.astype(dtype),
+            varB=varB.astype(dtype),
+            nB=nB,
+            top_n=top_n,
+            diffexp_lfc_cutoff=lfc_cutoff,
         )
 
     # ---- metadata: colors, uns, genesets ----------------------------------

--- a/server/dataset/zarr_dataset.py
+++ b/server/dataset/zarr_dataset.py
@@ -1,11 +1,18 @@
+import functools
+import os
+import tempfile
+import threading
 from copy import deepcopy
 from typing import Optional
+from urllib.parse import urlparse
 
 import anndata
+import boto3
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 import zarr
+from botocore.exceptions import BotoCoreError, ClientError
 
 from server.common.constants import XApproximateDistribution
 from server.common.errors import DatasetAccessError
@@ -16,6 +23,43 @@ from server.common.utils.type_conversion_utils import (
 )
 from server.compute.diffexp_cxg import diffexp_ttest_from_mean_var, mean_var_n
 from server.dataset.dataset import Dataset
+
+# Serializes concurrent first-time downloads of the same prefix (lru_cache memoizes the
+# *result* but not the compute, so two requests could otherwise download in parallel).
+_S3_DOWNLOAD_LOCK = threading.Lock()
+
+
+@functools.lru_cache(maxsize=8)  # small set of demo datasets per process; not a general cache
+def _materialize_s3_zarr(uri: str) -> str:
+    """Download an s3:// zarr prefix to a local temp dir and return the path.
+
+    ponytail: the pinned fsspec (0.7.4) is too old for zarr's FSStore array reads
+    (FSMap lacks getitems), so we download instead of stream.
+
+    Known limits (acceptable for the demo, not production):
+    - Assumes the dataset is immutable: a path present locally is never re-fetched,
+      so updates to the same s3 uri won't be picked up until the process restarts.
+    - The temp dir is a deliberate cache and is not cleaned up during the process
+      lifetime; the OS reclaims tempdir on reboot.
+    Upgrade path: bump fsspec/s3fs and read via FSStore, or go lazy (out-of-core)."""
+    parsed = urlparse(uri)
+    bucket, prefix = parsed.netloc, parsed.path.lstrip("/").rstrip("/") + "/"
+    local_root = os.path.join(tempfile.gettempdir(), "zarr_cache", bucket, prefix.rstrip("/"))
+    s3 = boto3.client("s3")
+    try:
+        with _S3_DOWNLOAD_LOCK:
+            for page in s3.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix):
+                for obj in page.get("Contents", []):
+                    rel = obj["Key"][len(prefix) :]
+                    if not rel:
+                        continue
+                    dest = os.path.join(local_root, rel)
+                    os.makedirs(os.path.dirname(dest), exist_ok=True)
+                    if not os.path.exists(dest):
+                        s3.download_file(bucket, obj["Key"], dest)
+    except (BotoCoreError, ClientError) as e:
+        raise DatasetAccessError(f"Failed to fetch zarr dataset from {uri}: {e}") from None
+    return local_root
 
 
 class ZarrDataset(Dataset):
@@ -29,7 +73,10 @@ class ZarrDataset(Dataset):
 
     def __init__(self, data_locator, app_config=None):
         super().__init__(data_locator, app_config)
-        self.adata = anndata.read_zarr(data_locator.uri_or_path)
+        path = data_locator.uri_or_path
+        if str(path).startswith("s3://"):
+            path = _materialize_s3_zarr(str(path))
+        self.adata = anndata.read_zarr(path)
         self.schema = None
         self._obs_index_name = self.adata.obs.index.name or "name_0"
         self._var_index_name = self.adata.var.index.name or "name_0"

--- a/server/dataset/zarr_dataset.py
+++ b/server/dataset/zarr_dataset.py
@@ -1,0 +1,261 @@
+from copy import deepcopy
+from typing import Optional
+
+import anndata
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+import zarr
+
+from server.common.constants import XApproximateDistribution
+from server.common.errors import DatasetAccessError
+from server.common.fbs.matrix import encode_matrix_fbs
+from server.common.utils.type_conversion_utils import (
+    get_schema_type_hint_from_dtype,
+    get_schema_type_hint_of_array,
+)
+from server.compute.diffexp_cxg import diffexp_ttest_from_mean_var, mean_var_n
+from server.dataset.dataset import Dataset
+
+
+class ZarrDataset(Dataset):
+    """Read-only POC adaptor serving an AnnData .zarr store.
+
+    ponytail: loads the whole AnnData into memory via anndata.read_zarr. Fine for the POC and
+    small fixtures; for large out-of-core datasets the upgrade path is anndata lazy reads
+    (read_elem / experimental.read_dispatched) or slicing raw zarr arrays directly. Writes
+    (user annotations / gene sets) are intentionally not implemented.
+    """
+
+    def __init__(self, data_locator, app_config=None):
+        super().__init__(data_locator, app_config)
+        self.adata = anndata.read_zarr(data_locator.uri_or_path)
+        self.schema = None
+        self._obs_index_name = self.adata.obs.index.name or "name_0"
+        self._var_index_name = self.adata.var.index.name or "name_0"
+
+    # ---- lifecycle ---------------------------------------------------------
+
+    @staticmethod
+    def pre_load_validation(data_locator):
+        if not data_locator.exists():
+            raise DatasetAccessError("Dataset does not exist.")
+
+    @staticmethod
+    def open(data_locator, app_config):
+        return ZarrDataset(data_locator, app_config)
+
+    @staticmethod
+    def file_size(data_locator):
+        return 0  # POC: not tracked
+
+    def cleanup(self):
+        pass
+
+    def get_name(self):
+        return "zarr_dataset"
+
+    def get_library_versions(self):
+        return {"anndata": anndata.__version__, "zarr": zarr.__version__}
+
+    # ---- shape & axis frames ----------------------------------------------
+
+    def get_shape(self):
+        return self.adata.shape
+
+    def _axis_frame(self, axis) -> pd.DataFrame:
+        """Return obs/var as a DataFrame with the index promoted to a named column,
+        mirroring the cxg layout where the index is stored as a regular attribute."""
+        axis = str(axis)
+        if axis == "obs":
+            df, index_name = self.adata.obs, self._obs_index_name
+        else:
+            df, index_name = self.adata.var, self._var_index_name
+        if index_name in df.columns:
+            return df
+        out = df.copy()
+        out.insert(0, index_name, df.index.to_numpy())
+        return out
+
+    def get_obs_columns(self):
+        return self._axis_frame("obs").columns
+
+    def get_obs_keys(self):
+        return list(self._axis_frame("obs").columns)
+
+    def get_var_keys(self):
+        return list(self._axis_frame("var").columns)
+
+    def get_obs_index(self):
+        return self.adata.obs.index.to_numpy()
+
+    @staticmethod
+    def _as_query_array(series):
+        # Base-class filter logic (dataset.py) treats only category/object/boolean as string-like.
+        # anndata returns pandas extension "string"/"str" dtype -> coerce to numpy object like CxgDataset.
+        if pd.api.types.is_categorical_dtype(series):
+            return series.values
+        if pd.api.types.is_extension_array_dtype(series.dtype) and not pd.api.types.is_numeric_dtype(series.dtype):
+            return np.asarray(series, dtype=object)
+        return series.values
+
+    def query_obs_array(self, term_name):
+        try:
+            return self._as_query_array(self._axis_frame("obs")[term_name])
+        except KeyError:
+            raise DatasetAccessError("query_obs") from None
+
+    def query_var_array(self, term_name):
+        try:
+            return self._as_query_array(self._axis_frame("var")[term_name])
+        except KeyError:
+            raise DatasetAccessError("query_var") from None
+
+    # ---- embeddings --------------------------------------------------------
+
+    def _obsm_key(self, ename):
+        return ename if ename in self.adata.obsm else f"X_{ename}"
+
+    def get_embedding_names(self):
+        names = [k[2:] if k.startswith("X_") else k for k in self.adata.obsm.keys()]
+        if not names:
+            raise DatasetAccessError("zarr matrix missing embeddings")
+        return names
+
+    def get_embedding_array(self, ename, dims=2):
+        arr = np.asarray(self.adata.obsm[self._obsm_key(ename)])
+        return arr[:, 0:dims]
+
+    # ---- X -----------------------------------------------------------------
+
+    def get_X_array(self, obs_mask=None, var_mask=None):
+        X = self.adata.X
+        obs_idx = slice(None) if obs_mask is None else np.nonzero(obs_mask)[0]
+        var_idx = slice(None) if var_mask is None else np.nonzero(var_mask)[0]
+        sub = X[obs_idx, :][:, var_idx]
+        if sp.issparse(sub):
+            sub = sub.toarray()
+        return np.asarray(sub)
+
+    def get_X_array_dtype(self):
+        return self.adata.X.dtype
+
+    def get_X_approximate_distribution(self) -> XApproximateDistribution:
+        dist = self.adata.uns.get("X_approximate_distribution") if self.adata.uns else None
+        if dist == XApproximateDistribution.COUNT.value:
+            return XApproximateDistribution.COUNT
+        return XApproximateDistribution.NORMAL
+
+    # ---- diffexp (backend-agnostic math, in-memory submatrices) -----------
+
+    def compute_diffexp_ttest(self, setA, setB, top_n=None, lfc_cutoff=None, selector_lists=False):
+        if top_n is None:
+            top_n = self.app_config.default_dataset__diffexp__top_n
+        if lfc_cutoff is None:
+            lfc_cutoff = self.app_config.default_dataset__diffexp__lfc_cutoff
+
+        n_obs = self.get_shape()[0]
+        rowsA = np.asarray(setA) if selector_lists else np.nonzero(setA)[0]
+        rowsB = np.asarray(setB) if selector_lists else np.nonzero(setB)[0]
+
+        dist = self.get_X_approximate_distribution()
+        dtype = self.get_X_array_dtype()
+
+        def mask(rows):
+            m = np.zeros((n_obs,), dtype=np.bool_)
+            m[rows] = True
+            return m
+
+        meanA, varA, nA = mean_var_n(self.get_X_array(mask(rowsA)), dist)
+        meanB, varB, nB = mean_var_n(self.get_X_array(mask(rowsB)), dist)
+        return diffexp_ttest_from_mean_var(
+            meanA=meanA.astype(dtype), varA=varA.astype(dtype), nA=nA,
+            meanB=meanB.astype(dtype), varB=varB.astype(dtype), nB=nB,
+            top_n=top_n, diffexp_lfc_cutoff=lfc_cutoff,
+        )
+
+    # ---- metadata: colors, uns, genesets ----------------------------------
+
+    def get_colors(self):
+        if not self.adata.uns:
+            return dict()
+        colors = self.adata.uns.get("cxg_category_colors", dict())
+        return dict(colors)
+
+    def get_uns(self, metadata_key):
+        if not self.adata.uns:
+            return None
+        return self.adata.uns.get(metadata_key)
+
+    def get_genesets(self, user_id: Optional[str] = None):
+        return {"genesets": [], "tid": 0}
+
+    # ---- schema ------------------------------------------------------------
+
+    def _column_schema(self, name, series, axis):
+        hint = get_schema_type_hint_of_array(series)
+        schema = dict(name=name, writable=False, **hint)
+        # cellxgene client treats obs booleans as categorical
+        if axis == "obs" and schema.get("type") == "boolean":
+            schema["type"] = "categorical"
+            schema["categories"] = [str(c) for c in pd.Categorical(series.astype("bool")).categories.tolist()]
+        return schema
+
+    def _get_schema(self):
+        shape = self.get_shape()
+        dataframe = {
+            "nObs": shape[0],
+            "nVar": shape[1],
+            **get_schema_type_hint_from_dtype(dtype=self.get_X_array_dtype(), allow_int64=True),
+        }
+
+        annotations = {}
+        for ax, index_name in (("obs", self._obs_index_name), ("var", self._var_index_name)):
+            frame = self._axis_frame(ax)
+            cols = []
+            for name in frame.columns:
+                col = self._column_schema(name, frame[name], ax)
+                # cxg skips int64 obs columns; mirror so the client filter logic matches
+                if ax == "obs" and col.get("type") in ("int64", "uint64"):
+                    continue
+                cols.append(col)
+            annotations[ax] = dict(columns=cols, index=index_name)
+
+        obs_layout = []
+        for ename in self.get_embedding_names():
+            ndim = np.asarray(self.adata.obsm[self._obsm_key(ename)]).shape[1]
+            obs_layout.append({"name": ename, "type": "float32", "dims": [f"{ename}_{d}" for d in range(ndim)]})
+
+        return {"dataframe": dataframe, "annotations": annotations, "layout": {"obs": obs_layout}}
+
+    def get_schema(self, user_id: Optional[str] = None):
+        if self.schema is None:
+            self.schema = self._get_schema()
+        return deepcopy(self.schema)
+
+    # ---- annotations -> fbs ------------------------------------------------
+
+    def annotation_to_fbs_matrix(self, axis, fields=None, num_bins=None, user_id: Optional[str] = None):
+        frame = self._axis_frame(axis)
+        if fields:
+            missing = [f for f in fields if f not in frame.columns]
+            if missing:
+                raise KeyError(missing[0])
+            df = frame[list(fields)].copy()
+        else:
+            df = frame.copy()
+        return encode_matrix_fbs(df, col_idx=df.columns, num_bins=num_bins)
+
+    # ---- writes: not supported in read-only POC ---------------------------
+
+    def get_saved_obs_annotations(self, user_id: Optional[str] = None):
+        return None
+
+    def get_saved_gene_sets(self, user_id: Optional[str] = None):
+        return None
+
+    def save_obs_annotations(self, dataframe, user_id: Optional[str] = None):
+        raise NotImplementedError("ZarrDataset is read-only (POC)")
+
+    def save_gene_sets(self, genesets_payload, tid: Optional[int] = None, user_id: Optional[str] = None):
+        raise NotImplementedError("ZarrDataset is read-only (POC)")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -23,6 +23,7 @@ scipy==1.14.1
 flask-server-timing==0.1.2
 s3fs==0.4.2
 tiledb==0.34.0
+zarr<3  # POC: Zarr-backed adaptor; anndata 0.10 requires zarr v2
 Werkzeug==3.0.6
 python-json-logger==2.0.7
 anthropic>=0.40.0

--- a/server/tests/unit/dataset/test_zarr_dataset.py
+++ b/server/tests/unit/dataset/test_zarr_dataset.py
@@ -50,9 +50,7 @@ class TestZarrDataset(unittest.TestCase):
             {c["name"] for c in sz["annotations"]["obs"]["columns"]},
             {c["name"] for c in sc["annotations"]["obs"]["columns"]},
         )
-        self.assertEqual(
-            sz["annotations"]["obs"]["index"], sc["annotations"]["obs"]["index"]
-        )
+        self.assertEqual(sz["annotations"]["obs"]["index"], sc["annotations"]["obs"]["index"])
 
     def test_x_slice(self):
         var_mask = np.zeros(self.cxg.get_shape()[1], dtype=bool)
@@ -89,12 +87,8 @@ class TestZarrDataset(unittest.TestCase):
         rz = self.zarr.compute_diffexp_ttest(maskA, maskB, top_n=10)
         rc = self.cxg.compute_diffexp_ttest(maskA, maskB, top_n=10)
         # same top gene indices
-        self.assertEqual(
-            [r[0] for r in rz["positive"]], [r[0] for r in rc["positive"]]
-        )
-        np.testing.assert_allclose(
-            [r[1] for r in rz["positive"]], [r[1] for r in rc["positive"]], rtol=1e-4
-        )
+        self.assertEqual([r[0] for r in rz["positive"]], [r[0] for r in rc["positive"]])
+        np.testing.assert_allclose([r[1] for r in rz["positive"]], [r[1] for r in rc["positive"]], rtol=1e-4)
 
 
 if __name__ == "__main__":

--- a/server/tests/unit/dataset/test_zarr_dataset.py
+++ b/server/tests/unit/dataset/test_zarr_dataset.py
@@ -1,0 +1,101 @@
+"""Parity tests for the Zarr-backed adaptor POC.
+
+Generates a zarr fixture from pbmc3k.cxg (once) and asserts the ZarrDataset adaptor returns
+the same shapes/values as the CxgDataset adaptor for the read pipeline.
+"""
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from server.common.constants import Axis
+from server.common.utils.data_locator import DataLocator
+from server.dataset.cxg_dataset import CxgDataset
+from server.dataset.zarr_dataset import ZarrDataset
+from server.tests import FIXTURES_ROOT, decode_fbs
+from server.tests.unit import app_config
+
+ZARR_PATH = os.path.join(tempfile.gettempdir(), "pbmc3k_test.zarr")
+
+
+class TestZarrDataset(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from scripts.cxg_to_zarr import convert
+
+        if not os.path.exists(ZARR_PATH):
+            convert(f"{FIXTURES_ROOT}/pbmc3k.cxg", ZARR_PATH)
+
+    def setUp(self):
+        config = app_config()
+        self.cxg = CxgDataset(DataLocator(f"{FIXTURES_ROOT}/pbmc3k.cxg"), config)
+        self.zarr = ZarrDataset(DataLocator(ZARR_PATH), config)
+
+    def test_shape(self):
+        self.assertEqual(self.zarr.get_shape(), self.cxg.get_shape())
+
+    def test_embeddings(self):
+        self.assertEqual(sorted(self.zarr.get_embedding_names()), sorted(self.cxg.get_embedding_names()))
+        emb_z = self.zarr.get_embedding_array("umap", 2)
+        emb_c = self.cxg.get_embedding_array("umap", 2)
+        np.testing.assert_allclose(emb_z, emb_c, rtol=1e-5)
+
+    def test_schema_structure(self):
+        sz = self.zarr.get_schema()
+        sc = self.cxg.get_schema()
+        self.assertEqual(sz["dataframe"]["nObs"], sc["dataframe"]["nObs"])
+        self.assertEqual(sz["dataframe"]["nVar"], sc["dataframe"]["nVar"])
+        self.assertEqual(
+            {c["name"] for c in sz["annotations"]["obs"]["columns"]},
+            {c["name"] for c in sc["annotations"]["obs"]["columns"]},
+        )
+        self.assertEqual(
+            sz["annotations"]["obs"]["index"], sc["annotations"]["obs"]["index"]
+        )
+
+    def test_x_slice(self):
+        var_mask = np.zeros(self.cxg.get_shape()[1], dtype=bool)
+        var_mask[:5] = True
+        xz = self.zarr.get_X_array(None, var_mask)
+        xc = self.cxg.get_X_array(None, var_mask)
+        self.assertEqual(xz.shape, xc.shape)
+        np.testing.assert_allclose(xz, xc, rtol=1e-5)
+
+    def test_obs_annotation_fbs(self):
+        col = "louvain"
+        fz = decode_fbs.decode_matrix_FBS(self.zarr.annotation_to_fbs_matrix(Axis.OBS, fields=[col]))
+        fc = decode_fbs.decode_matrix_FBS(self.cxg.annotation_to_fbs_matrix(Axis.OBS, fields=[col]))
+        self.assertEqual(list(fz["columns"][0]), list(fc["columns"][0]))
+
+    def test_var_name_filter_expression(self):
+        # exercises the base-class string filter path (regression: extension-string dtype)
+        from werkzeug.datastructures import MultiDict
+
+        from server.common.rest import _query_parameter_to_filter
+
+        filt = _query_parameter_to_filter(MultiDict([("var:name_0", "SIK1")]))
+        fz = decode_fbs.decode_matrix_FBS(self.zarr.data_frame_to_fbs_matrix(filt, Axis.VAR))
+        fc = decode_fbs.decode_matrix_FBS(self.cxg.data_frame_to_fbs_matrix(filt, Axis.VAR))
+        self.assertEqual(fz["n_cols"], 1)
+        np.testing.assert_allclose(fz["columns"][0], fc["columns"][0], rtol=1e-5)
+
+    def test_diffexp_parity(self):
+        n_obs = self.cxg.get_shape()[0]
+        maskA = np.zeros(n_obs, dtype=bool)
+        maskB = np.zeros(n_obs, dtype=bool)
+        maskA[: n_obs // 2] = True
+        maskB[n_obs // 2 :] = True
+        rz = self.zarr.compute_diffexp_ttest(maskA, maskB, top_n=10)
+        rc = self.cxg.compute_diffexp_ttest(maskA, maskB, top_n=10)
+        # same top gene indices
+        self.assertEqual(
+            [r[0] for r in rz["positive"]], [r[0] for r in rc["positive"]]
+        )
+        np.testing.assert_allclose(
+            [r[1] for r in rz["positive"]], [r[1] for r in rc["positive"]], rtol=1e-4
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vcp-infra/.infra/rdev/values.yaml
+++ b/vcp-infra/.infra/rdev/values.yaml
@@ -13,7 +13,7 @@ stack:
         annotations:
           "eks.amazonaws.com/role-arn": arn:aws:iam::058264139299:role/virtual-cells-platform-backend-dev
       image:
-        tag: sha-dc4b0fa
+        tag: sha-7a74a5a
       replicaCount: 1
       ingress:
         oidcProtected: false

--- a/vcp-infra/.infra/rdev/values.yaml
+++ b/vcp-infra/.infra/rdev/values.yaml
@@ -13,7 +13,7 @@ stack:
         annotations:
           "eks.amazonaws.com/role-arn": arn:aws:iam::058264139299:role/virtual-cells-platform-backend-dev
       image:
-        tag: sha-14fc6b5
+        tag: sha-dc4b0fa
       replicaCount: 1
       ingress:
         oidcProtected: false


### PR DESCRIPTION
<!--ARGUS_STACK_DETAILS_START:app=single-cell-explorer&env=rdev&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
<details open>
  <summary>Argus Stack Details</summary>
  <br />
  <table>
    <tr>
      <th>Stack Name</th>
      <th>Env Name</th>
      <th>App Name</th>
    </tr>
    <tr>
      <td>complete-goblin</td>
      <td>rdev</td>
      <td>single-cell-explorer</td>
    </tr>
  </table>
  <table>
    <tr>
      <th>Stack Base URL</th>
      <td><a href="https://complete-goblin.dev-sc.dev.czi.team" target="_blank">https://complete-goblin.dev-sc.dev.czi.team</a></td>
    </tr>
    <tr>
      <th>ArgoCD URL</th>
      <td><a href="https://argo.prod.platform.si.czi.technology/applications/argocd/complete-goblin" target="_blank">https://argo.prod.platform.si.czi.technology/applications/argocd/complete-goblin</a></td>
    </tr>
    <tr>
      <th>Dashboard URL</th>
      <td><a href="https://g-2c3bce61e8.grafana-workspace.us-west-2.amazonaws.com/d/complete-goblin" target="_blank">https://g-2c3bce61e8.grafana-workspace.us-west-2.amazonaws.com/d/complete-goblin</a></td>
    </tr>
  </table>
</details>

---
<!--ARGUS_STACK_DETAILS_END:app=single-cell-explorer&env=rdev&server=https://argus.core-platform.prod.czi.team:do not remove this marker as it will break the argus metadata functionality-->
## What

Proof-of-concept evaluating **Zarr** as an alternative storage backend to TileDB/CXG. Adds a read-only `ZarrDataset(Dataset)` that serves the full read pipeline (schema, obs/var annotations, X expression, embeddings, diffexp, uns/colors) from an AnnData `.zarr` store via `anndata.read_zarr` — without touching the REST, fbs-encoding, or compute layers.

## Why it's cheap

The `Dataset` ABC already implements all backend-agnostic logic (filter→mask, diffexp orchestration, fbs encoding, embedding normalization). The POC is one new adaptor class + a one-line dispatch.

## Changes

- **`server/dataset/zarr_dataset.py`** — new adaptor implementing the `Dataset` ABC against an in-memory AnnData.
- **`server/dataset/matrix_loader.py`** — suffix dispatch: `.zarr` → `ZarrDataset`, else `CxgDataset`.
- **`server/common/rest.py`** — let `.zarr` datasets bypass the hardcoded `.cxg` rewrite in `s3_uri_get`.
- **`scripts/cxg_to_zarr.py`** — converter that reads a `.cxg` via `CxgDataset` and writes an apples-to-apples `.zarr` fixture (rebuilds categoricals from the cxg schema).
- **`server/tests/unit/dataset/test_zarr_dataset.py`** — parity tests vs `CxgDataset`.
- **`server/requirements.txt`** — `zarr<3` (anndata 0.10 needs zarr v2).

Diffexp reuses the backend-agnostic `mean_var_n` / `diffexp_ttest_from_mean_var`.

## Verification

- **Unit:** 7 parity tests (shape, embeddings, schema, X slice, obs annotation fbs, var-name filter, diffexp) — all byte/value-identical to the `.cxg` fixture. Existing cxg suite stays green.
- **End-to-end:** launched the dev backend + frontend against a generated `pbmc3k.zarr`. Every Explorer load endpoint returns 200 (`config`, `schema`, `colors`, `annotations/obs`, `layout/obs`), and `data/var` + `diffexp/obs` match the TileDB dataset exactly (e.g. SIK1 expression sum −2.2767 in both).

## Out of scope (follow-ups if this proceeds)

Writes (user annotations / gene sets), S3/fsspec reads, ATAC coverage, multi-version schema, out-of-core X (whole AnnData loads into memory — marked in the class docstring with the upgrade path).

